### PR TITLE
Implement HashTable and Result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ luac.out
 *.x86_64
 *.hex
 
+std

--- a/hashtable.t
+++ b/hashtable.t
@@ -2,12 +2,24 @@ local A = require 'std.alloc'
 local O = require 'std.object' 
 local M = {}
 
+-- Default hash function. This is an implementation of djb2. Treats a block of data as an array of bytes.
+local terra default_hash(data: &uint8, size: uint): uint
+	var hash: uint = 5381
+
+	for i = 0, size do
+		hash = ((hash << 5) + hash * 33) + data[i]
+	end
+
+	return hash
+end
+
 --[[ 
 	Creates a new HashTable type.
 
 	This hashtable is based on the dense_hash_set implementation by Google.
 --]]
-function M.HashTable(Key, GroupLength, Alloc)
+function M.HashTable(Key, HashFn, GroupLength, Alloc)
+	HashFn = HashFn or default_hash
 	GroupLength = GroupLength or 48
 	Alloc = Alloc or A.default_allocator
 

--- a/hashtable.t
+++ b/hashtable.t
@@ -4,7 +4,7 @@ local O = require 'std.object'
 local CStr = terralib.includec("string.h")
 
 --[[ Factory function for default hash functions of various types. Generally, the hashing functions outputted are implementation of djb2. ]]--
-function CreateDefaultHashFunction(KeyType)
+local function CreateDefaultHashFunction(KeyType)
 	local function ComputeSize(keyValue)
 		if KeyType == rawstring then
 			return `CStr.strlen(keyValue)
@@ -26,7 +26,7 @@ function CreateDefaultHashFunction(KeyType)
 	return hash_function
 end
 
-function CreateDefaultEqualityFunction(KeyType)
+local function CreateDefaultEqualityFunction(KeyType)
 	local terra equal_function(k1: KeyType, k2: KeyType): bool
 		return k1 == k2
 	end
@@ -38,7 +38,7 @@ end
 
 	This hashtable is based on the dense_hash_set implementation by Google.
 --]]
-function HashTable(KeyType, EqFn, HashFn, Alloc)
+local function HashTable(KeyType, EqFn, HashFn, Alloc)
 	EqFn = EqFn or CreateDefaultEqualityFunction(KeyType)
 	HashFn = HashFn or CreateDefaultHashFunction(KeyType)
 	Alloc = Alloc or A.default_allocator
@@ -69,8 +69,8 @@ function HashTable(KeyType, EqFn, HashFn, Alloc)
 	-- Returns a pointer to the metadata array and a pointer to the bucket array.
 	local terra malloc_by_groups(groups: uint): tuple(&uint8, &KeyType)
 		var buckets = groups * GroupLength
-		var big_ol_chunk_of_memory = [ Alloc ]:alloc_raw(buckets + (sizeof([KeyType]) * buckets))
-		return { [&uint8] (big_ol_chunk_of_memory), [&KeyType] ([&uint8] (big_ol_chunk_of_memory) + GroupLength) }
+		var chunk_of_memory = [ Alloc ]:alloc_raw(buckets + (sizeof([KeyType]) * buckets))
+		return { [&uint8] (chunk_of_memory), [&KeyType] ([&uint8] (chunk_of_memory) + GroupLength) }
 	end
 
 	-- Initalizes the metadata array with MetadataEmpty

--- a/hashtable.t
+++ b/hashtable.t
@@ -116,6 +116,9 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 		buckets: &BucketType
 	}
 
+	function HashTable.metamethods.__typename(self)
+		return "HashTable[" .. tostring(KeyType) .. (ValueType ~= nil and ", " .. tostring(ValueType) or "") .. "]"
+	end
 
 	-- Result types
 	local CallocResult = R.MakeResult(tuple(&opaque, &uint8, &BucketType), M.Errors.ErrorType)

--- a/hashtable.t
+++ b/hashtable.t
@@ -67,10 +67,19 @@ function HashTable(Key, HashFn, GroupLength, Alloc)
 			metadata = [&int8] (big_ol_chunk_of_memory),
 			buckets =  [&Key] ( [&int8] (big_ol_chunk_of_memory) + [ GroupLength ])
 		}
+
+		-- Initialize the metadata array
+		for i = 0, self.capacity do
+			self.metadata[i] = 128 -- 0b10000000
+		end
 	end
 
 	terra Hashtable:insert(key: Key)
 		var hash = [ HashFn ](key)
+		var bucket_index = hash % self.capacity
+
+		self.metadata[bucket_index] = hash & 127 -- 0b01111111
+		self.buckets[bucket_index] = key
 	end
 
 	return Hashtable

--- a/hashtable.t
+++ b/hashtable.t
@@ -1,0 +1,46 @@
+local A = require 'std.alloc'
+local O = require 'std.object' 
+local M = {}
+
+--[[ 
+	Creates a new HashTable type.
+
+	This hashtable is based on the dense_hash_set implementation by Google.
+--]]
+function M.HashTable(Key, GroupLength, Alloc)
+	GroupLength = GroupLength or 48
+	Alloc = Alloc or A.default_allocator
+
+	local struct Entry {
+		value: &Key
+	}
+
+	local struct Hashtable(O.Object) {
+		-- The total number of buckets in the table.
+		capacity: uint
+		-- Array of bytes holding the metadata of the table.
+		metadata: &int8
+		-- The backing array of the hashtable.
+		buckets: &Key
+	}
+
+	-- Allocates memory large enough to fit the provided number of groups and associated metadata. Returns a pointer to this block of memory.
+	local terra malloc_by_groups(groups: uint): &opaque
+		buckets = groups * [ GroupLength ]
+		return [ Alloc ].alloc(groups + (sizeof([Key]) * buckets))
+	end
+
+	terra Hashtable:init()
+		var big_ol_chunk_of_memory = malloc_by_groups(1)
+		
+		self:_init {
+			capacity = [ GroupLength ],
+			metadata = big_ol_chunk_of_memory,
+			buckets = big_ol_chunk_of_memory[ [GroupLength] ]
+		}
+	end
+
+	return HashTable
+end
+
+return M

--- a/hashtable.t
+++ b/hashtable.t
@@ -17,10 +17,10 @@ local M = {}
 M.CTHashTable = CT.All(
 	CT.Field("capacity", CT.Integral),
 	CT.Field("size", CT.Integral),
-	CT.Method("resize", nil, CT.Integral),
+	CT.Method("resize", CT.Empty, CT.Integral),
 	CT.MetaConstraint(
 		function(KeyType, ValueType, HandleType)
-			local lookup_constraint = CT.Method("lookup_handle", CT.Type(KeyType), CT.Type(HandleType)),
+			local lookup_constraint = CT.Method("lookup_handle", CT.Type(KeyType), CT.Type(HandleType))
 			
 			if ValueType ~= nil then
 				local store_constraint = CT.Method("store_handle", {CT.Type(HandleType), CT.Type(KeyType), CT.Type(ValueType)}, CT.Integral)
@@ -139,7 +139,7 @@ function M.Implementation.DenseHashTable(KeyType, ValueType, HashFn, EqFn, Alloc
 			[Alloc]:free_raw(self.opaque_ptr)
 		end
 
-		CStr.memset(self, 0, sizeof(SM.HashTable)
+		CStr.memset(self, 0, sizeof(SM.HashTable))
 	end
 
 	terra DenseHashTable:lookup_handle(key: KeyType): BucketHandle 
@@ -171,7 +171,7 @@ function M.Implementation.DenseHashTable(KeyType, ValueType, HashFn, EqFn, Alloc
 			[self].metadata[index] = hash_result.h2
 			[self].buckets[index] = escape
 				if ValueType ~= nil then
-					emit(`BucketType { key = [key], value = [value])
+					emit(`BucketType { key = [key], value = [value] })
 				else
 					emit(`key)
 				end
@@ -222,7 +222,7 @@ function M.Implementation.DenseHashTable(KeyType, ValueType, HashFn, EqFn, Alloc
 		var new_capacity = self.capacity * 2
 		var alloc_success, new_opaque_ptr, new_metadata, new_buckets = table_calloc(new_capacity)
 
-		if ~alloc_success then
+		if not alloc_success then
 			return -1
 		end
 
@@ -245,7 +245,7 @@ function M.Implementation.DenseHashTable(KeyType, ValueType, HashFn, EqFn, Alloc
 					end
 				end
 
-				if result != 0 then
+				if result ~= 0 then
 					-- An error occured when rehashing. Reset the state of the hashtable and return an error.
 					reassign_internals(self, old_capacity, old_size, old_opaque_ptr, old_metadata, old_buckets)
 					[Alloc]:free(new_opaque_ptr)

--- a/hashtable.t
+++ b/hashtable.t
@@ -337,6 +337,11 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 		index: uint
 	}
 
+	-- Creating a custom typename that shows which HashTable this Entry is bound too
+	function Entry.metamethods.__typename(self)
+		return "Entry-" .. tostring(HashTable)
+	end
+
 	local EntryResult = R.MakeResult(Entry, M.Errors.ErrorType)
 
 	terra HashTable:entry(key: KeyType): EntryResult

--- a/hashtable.t
+++ b/hashtable.t
@@ -286,6 +286,23 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 		end
 	end
 
+	terra HashTable:remove(key: KeyType): uint
+		var result = hash_probe(key, self.metadata, self.buckets, self.capacity)
+
+		if result:is_ok() then
+			var hash_info, index = result.ok
+
+			if self.metadata[index] ~= MetadataEmpty then
+				self.metadata[index] == MetadataEmpty
+				CStr.memset(self.buckets + index, 0, sizeof(BucketType))
+			end
+
+			return 0
+		else
+			return result.err
+		end
+	end
+
 	local InsertBody = macro(function(self, bucket)
 		return quote
 			if [self].size == [self].capacity then

--- a/hashtable.t
+++ b/hashtable.t
@@ -1,10 +1,271 @@
 local A = require 'std.alloc'
 local O = require 'std.object' 
+local R = require 'std.result'
 
 local CStr = terralib.includec("string.h")
 local Cstdio = terralib.includec("stdio.h")
 
 local M = {}
+
+-- Using error codes instead of strings because it's easier to define the nature of the error since we don't have standardized error types.
+function M.Errors = {
+	-- There was an error allocating memory
+	AllocationError = constant(uint, 1)
+	-- An error occured because the hash_table is at capacity
+	AtCapacity = constant(uint, 2)
+}
+
+function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
+	local MetadataHashBitmap = constant(uint8, 127) -- 0b01111111
+	local MetadataEmpty = constant(uint8, 128) -- 0b10000000
+	local GroupLength = constant(uint, 16)
+
+	-- Determine if this hashtable should operate as a hash set or a hash map
+	local IsKeyValue = ValueType ~= nil
+	local BucketType = IsKeyValue and struct { key: KeyType, value: ValueType } or struct { key: KeyType }
+
+	local struct HashInformation {
+		initial_bucket_index: uint
+		h1: uint
+		h2: uint8
+	}
+
+	local struct FillInformation {
+		-- The old metadata of the bucket before a new item was placed
+		old_metadata: uint8
+		-- The index where the place occured.
+		index: uint
+	}
+
+	local struct HashTable(O.Object) {
+		-- The total number of buckets in the table.
+		capacity: uint
+		-- The number of items stored in the table
+		size: uint
+		-- Pointer to free on destruction
+		opaque_ptr: &opaque
+		-- Array of bytes holding the metadata of the table.
+		metadata: &uint8
+		-- The backing array of the hashtable.
+		buckets: &BucketType
+	}
+
+	-- Result types
+	local CallocResult = R.MakeResult(tuple(&opaque, &uint8, &BucketType), uint)
+	local ProbeResult = R.MakeResult(uint, uint)
+	local FillResult = R.MakeResult(FillInformation, uint)
+
+	-- Allocates and initalizes memory for the hashtable. The metadata array is initalized to `MetadataEmpty`. Buckets are not initialized to any value.
+	-- Returns a Result containing either a triple or an error code.
+	-- The triple consists of an opaque pointer which should be freed, a pointer to the metadata array, and a pointer to the bucket array.
+	local terra table_calloc(capacity: uint): CallocResult
+		var opaque_ptr = Alloc:alloc_raw(capacity * (sizeof(KeyType) + 1))
+		
+		if opaque_ptr == nil then
+			return CallocResult.err(M.Errors.AllocationError)
+		end
+
+		var metadata_array = [&uint8](opaque_ptr)
+		var buckets_array = [&KeyType](metadata_array + capacity)
+
+		CStr.memset(metadata_array, MetadataEmpty, capacity)
+
+		return CallocResult.ok{opaque_ptr, metadata_array, buckets_array}
+	end
+
+	local terra compute_hash_information(key: KeyType, capacity: uint): HashInformation
+		var hash = [ HashFn ](key)
+
+		return HashInformation {
+			initial_bucket_index = (hash >> 7) % capacity,
+			h1 = hash >> 7,
+			h2 = hash and MetadataHashBitmap
+		}
+	end
+
+	-- Probes the hash_table for the bucket that would contain the key. Returns a result containing either an index or an error code.
+	-- If the key exists in the hashtable, then the index returned refers to the bucket containing that key. 
+	-- If the key does not exist in the hashtable, then the index returned refers to an empty bucket where the key would be stored.
+	local terra linear_probe(hash_table: &HashTable, key: KeyType, hash: HashInformation): ProbeResult
+		for virtual_index = hash_result.initial_bucket_index, hash_table.capacity + hash_result.initial_bucket_index do
+			var index = virtual_index and (hash_table.capacity -1)
+			var metadata = hash_table.metadata[index]
+
+			if metadata == MetadataEmpty or (metadata == hash_result.h2 and [EqFn](key, hash_table.buckets[index].key)) then
+				return ProbeResult.ok(index)
+			end
+		end
+
+		return ProbeResult.err(M.Errors.AtCapacity)
+	end
+
+	-- Places the bucket in the hashtable.
+	-- This is effectively an insert operation but does not resize the hashtable if it is full.
+	local terra fill_bucket(hash_table: &HashTable, bucket: BucketType): FillResult 
+		var hash_info = compute_hash_information(bucket.key, hash_table.capacity)
+		var probe_result = linear_probe(hash_table, bucket.key, hash_info)
+
+		if probe_result.is_err() then
+			return FillResult.err(probe_result.err)
+		end
+
+		var index = probe_result.ok
+		var old_metadata = hash_table.metadata[index]
+		hash_table.metadata[index] = hash_info.h2
+		hash_table.buckets[index] = bucket
+
+		return FillResult.ok{old_metadata, index}
+	end
+
+	local terra find_next_power_of_two(starting: uint, minimum: uint): uint
+		while starting < minimum do
+			starting = starting * 2
+		end
+		
+		return starting
+	end
+
+	terra HashTable:init()
+		var initial_capacity = SM.GroupLength
+		var calloc_result = table_calloc(initial_capacity)
+		
+		if calloc_result.is_ok() then
+			var opaque_ptr, metadata, buckets = calloc_result.ok
+			
+			self:_init {
+				capacity = initial_capacity,
+				size = 0,
+				opaque_ptr = opaque_ptr,
+				metadata = metadata,
+				buckets = buckets
+			}
+		end
+	end
+
+	terra HashTable:destruct()
+		[Alloc]:free_raw()
+		CStr.memset(self, 0, sizeof(HashTable)) 
+	end
+
+	-- Resizes the hashtable to be at least the size of the requested_capacity. Returns 0 if there was no error. 
+	terra HashTable:resize(requested_capacity: uint): uint
+		-- If the requested_capacity is lower than self.capacity, return
+		if requested_capacity < self.capacity then
+			return 0
+		end
+
+		local old_capacity = self.capacity
+		local old_opaque = self.opaque_ptr
+		local old_metadata = self.metadata
+		local old_buckets = self.buckets
+
+		local new_capacity = find_next_power_of_two(self.capacity, requested_capacity) 
+		local calloc_result = table_calloc(new_capacity)
+
+		if calloc_result.is_err() then
+			return calloc_result.err
+		end
+
+		local new_opaque, new_metadata, new_buckets = calloc_result.ok 
+		self.capacity = new_capacity
+		self.opaque_ptr = new_opaque
+		self.metadata = new_metadata
+		self.buckets = new_buckets
+
+		-- Iterate through the old data and rehash existing entries
+		for i = 0, old_capacity do
+			if old_metadata[i] ~= MetadataEmpty then
+				var fill_result = fill_bucket(self, old_buckets[i])
+
+				if put_result.is_err() then
+					self.capacity = old_capacity
+					self.opaque_ptr = old_opaque
+					self.metadata = old_metadata
+					self.buckets = old_buckets
+
+					[Alloc]:free_raw(new_opaque)
+					
+					return put_result.err
+				end
+			end
+		end
+
+		[Alloc]:free_raw(old_opaque)
+		
+		return 0
+	end
+
+	terra HashTable:has(key: KeyType): bool
+		var hash_information = compute_hash_information(key, self.capacity)
+		var probe_result = linear_probe(self, key, hash_information)
+
+		if probe_result.is_ok() and self.metadata[probe_result.ok] ~= MetadataEmpty then
+			return true
+		else
+			return false
+		end
+	end
+
+	local InsertBody = macro(function(self, bucket)
+		return quote
+			if [self].size == [self].capacity then
+				[self].resize([self].capacity * 2)
+			end
+			
+			var fill_result = fill_bucket([self], [bucket])
+
+			if fill_result.is_err() then
+				return fill_result.err
+			end
+
+			if fill_result.ok.old_metadata ~= MetadataEmpty then
+				self.size = self.size + 1
+			end 
+
+			return 0
+		end
+	end)
+
+	if IsKeyValue then
+		terra HashTable:insert(key: KeyType, value: ValueType): uint
+			return InsertBody(self, BucketType { key = key, value = value })
+		end
+	else
+		terra HashTable:insert(key: KeyType): uint
+			return InsertBody(self, { key = key })
+		end
+	end
+
+	local DebugTypeInformation = "{ key: " .. tostring(KeyType) .. ( IsKeyValue and ", value: " .. tostring(ValueType)) .. " }"
+	local DebugHeaderString = "HashTable " .. DebugTypeInformation .. " Size: %u; Capacity: %u; OpaquePtr: %p\n"
+
+	-- Prints a debug view of the metadata array to stdout
+	terra HashTable:debug_metadata_repr()
+		Cstdio.printf(DebugHeaderString, self.size, self.capacity, self.opaque_ptr)
+		for i = 0, self.capacity do
+			Cstdio.printf("[%u]\t%p - 0x%02X\n", i, self.metadata + i, self.metadata[i])
+		end
+	end
+
+	-- Prints a debug view of the table to stdout.
+	terra HashTable:debug_full_repr()
+		Cstdio.printf(DebugHeaderString, self.size, self.capacity, self.opaque_ptr)
+		for i = 0, self.capacity do
+			Cstdio.printf("[%u]\tMetadata: %p = 0x%02X\tBucket: %p = ", i, self.metadata + i, self.metadata[i], self.buckets + i)
+
+			if self.metadata[i] == 128 then
+				Cstdio.printf("Empty\n", self.buckets + i)
+			elseif self.buckets + i == nil then
+				Cstdio.printf("NULLPTR\n")
+			else
+				-- TODO: this won't work all the time, refactor to handle all types later
+				Cstdio.printf("{ key = %s, value = %s }\n", self.buckets[i].key, self.buckets[i].value)
+			end
+		end
+	end
+
+	return HashTable
+end
 
 -- Implementation of djb2. Treats all data as a stream of bytes.
 terra M.hash_djb2(data: &int8, size: uint): uint
@@ -39,216 +300,3 @@ function M.CreateDefaultEqualityFunction(KeyType)
 	end
 	return naive_equal_function
 end
-
-function M.CreateHashTableSubModule(KeyType, HashFn, EqFn, Alloc)
-	HashFn = HashFn or M.CreateDefaultHashFunction(KeyType)
-	EqFn = EqFn or M.CreateDefaultEqualityFunction(KeyType)
-	Alloc = Alloc or A.default_allocator
-
-	local SM = {}
-
-	SM.MetadataHashBitmap = constant(uint8, 127) -- 0b01111111
-	SM.MetadataEmpty = constant(uint8, 128) -- 0b10000000
-	SM.GroupLength = constant(uint, 16)
-
-	-- Produces a collection of methods used for the HashTable implementation.
-	-- This is considered to be an implementation detail and subject to API changes. The only reason this is exposed is for automated testing purposes.
-	SM._Plumbing = {}
-
-	-- Allocates and initalizes memory for the hashtable. The metadata array is initalized to `MetadataEmpty`. Buckets are not initialized to any value.
-	-- Returns a quadruple: The first value is success, the second value is an opaque pointer which should be passed to `free`, the third value is the metadata array, and the forth value is the bucket array.
-	-- Note that if success is false, then all other values are null.
-	terra SM._Plumbing.table_calloc(capacity: uint): tuple(bool, &opaque, &uint8, &KeyType)
-		var opaque_ptr = Alloc:alloc_raw(capacity * (sizeof(KeyType) + 1))
-		
-		if opaque_ptr == nil then
-			return {false, nil, nil, nil}
-		end
-
-		var metadata_array = [&uint8](opaque_ptr)
-		var buckets_array = [&KeyType](metadata_array + capacity)
-
-		CStr.memset(metadata_array, SM.MetadataEmpty, capacity)
-
-		return {true, opaque_ptr, metadata_array, buckets_array}
-	end
-
-	struct SM._Plumbing.HashResult {
-		initial_bucket_index: uint
-		h1: uint
-		h2: uint8
-	}
-
-	terra SM._Plumbing.compute_hashes(key: KeyType, capacity: uint): SM._Plumbing.HashResult
-		var hash = [ HashFn ](key)
-
-		return SM._Plumbing.HashResult {
-			initial_bucket_index = (hash >> 7) % capacity,
-			h1 = hash >> 7,
-			h2 = hash and SM.MetadataHashBitmap
-		}
-	end
-
-	-- Probes the table for the bucket that would contain the key.
-	-- Expects that capacity is a power of 2.
-	-- Returns an index which is only valid for the current state of the table. The index may point to a bucket which contains an existing key, 
-	-- or to an empty bucket where the key should be inserted if the key does not exist.
-	-- The return value is negative if no bucket can be found.
-	terra SM._Plumbing.probe(key: KeyType,
-							 hash_result: SM._Plumbing.HashResult,
-							 metadata_array: &uint8,
-							 buckets: &KeyType,
-							 capacity: uint): int
-		for virtual_index = hash_result.initial_bucket_index, capacity + hash_result.initial_bucket_index do
-			var index = virtual_index and (capacity -1)
-			var metadata = metadata_array[index]
-
-			if metadata == SM.MetadataEmpty or (metadata == hash_result.h2 and [EqFn](key, buckets[index])) then
-				return index
-			end
-		end
-
-		return -1
-	end
-
-	SM._Plumbing.probe_table = macro(function(hash_table, key, hash_result)
-		return `SM._Plumbing.probe(key, hash_result, hash_table.metadata, hash_table.buckets, hash_table.capacity)
-	end)
-
-	-- Inserts a key into buckets and sets appropriate metadata.
-	-- The reason this is a plumbing function instead of public api is because rehash needs to perform insertions.
-	terra SM._Plumbing.insert(key: KeyType, metadata_array: &uint8, buckets: &KeyType, capacity: uint)
-		var hash_result = SM._Plumbing.compute_hashes(key, capacity)
-		var index = SM._Plumbing.probe(key, hash_result, metadata_array, buckets, capacity)
-
-		metadata_array[index] = hash_result.h2
-		buckets[index] = key
-	end
-
-	terra SM._Plumbing.rehash_table(old_metadata: &uint8,
-									old_buckets: &KeyType,
-									old_capacity: uint,
-									new_metadata: &uint8,
-									new_buckets: &KeyType,
-									new_capacity: uint)
-		for i = 0, old_capacity do
-			if old_metadata[i] ~= SM.MetadataEmpty then
-				var key = old_buckets[i]
-				SM._Plumbing.insert(key, new_metadata, new_buckets, new_capacity)
-			end
-		end
-	end
-
-	-- Resizes the hashtable.
-	-- Returns true on success, false otherwise.
-	terra SM._Plumbing.resize_hashtable(hashtable: &SM.HashTable): bool
-		var new_capacity = hashtable.capacity * 2
-		var alloc_success, opaque_ptr, new_metadata, new_buckets = SM._Plumbing.table_calloc(new_capacity)
-
-		if alloc_success == false then
-			return false
-		end
-
-		SM._Plumbing.rehash_table(hashtable.metadata, hashtable.buckets, hashtable.capacity, new_metadata, new_buckets, new_capacity)
-
-		[Alloc]:free_raw(hashtable.opaque_ptr)
-		hashtable.opaque_ptr = opaque_ptr
-		hashtable.metadata = new_metadata
-		hashtable.buckets = new_buckets
-		hashtable.capacity = new_capacity
-
-		return true
-	end
-	
-	struct SM.HashTable(O.Object) {
-		-- The total number of buckets in the table.
-		capacity: uint
-		-- The number of items stored in the table
-		size: uint
-		-- Pointer to free on destruction
-		opaque_ptr: &opaque
-		-- Array of bytes holding the metadata of the table.
-		metadata: &uint8
-		-- The backing array of the hashtable.
-		buckets: &KeyType
-	}
-
-	terra SM.HashTable:init()
-		var initial_capacity = SM.GroupLength
-		var alloc_success, opaque_ptr, metadata, buckets = SM._Plumbing.table_calloc(initial_capacity)
-		
-		self:_init {
-			capacity = initial_capacity,
-			size = 0,
-			opaque_ptr = opaque_ptr,
-			metadata = metadata,
-			buckets = buckets
-		}
-	end
-
-	terra SM.HashTable:destruct()
-		[Alloc]:free_raw(self.opaque_ptr)
-		self.opaque_ptr = nil
-		self.metadata = nil
-		self.buckets = nil
-		self.size = 0
-		self.capacity = 0
-	end
-
-	-- Inserts the key into the table. If the table is full, a resize is triggered.
-	terra SM.HashTable:insert(key: KeyType)
-		if self.size == self.capacity then
-			SM._Plumbing.resize_hashtable(self)
-		end
-
-		SM._Plumbing.insert(key, self.metadata, self.buckets, self.capacity)
-		self.size = self.size + 1
-	end
-
-	-- Tests if the table has a key of the specified value. Returns true if a value exists, false otherwise.
-	terra SM.HashTable:has(key: KeyType): bool
-		var hash_result = SM._Plumbing.compute_hashes(key, self.capacity)
-		var probe_index = SM._Plumbing.probe_table(self, key, hash_result)
-
-		if probe_index == -1 or self.metadata[probe_index] == SM.MetadataEmpty then
-			return false
-		end
-
-		return true
-	end
-
-	-- Prints a debug view of the metadata array to stdout
-	terra SM.HashTable:debug_metadata_repr()
-		Cstdio.printf("HashTable Size: %u, Capacity: %u, OpaquePtr: %p\n", self.size, self.capacity, self.opaque_ptr)
-		for i = 0, self.capacity do
-			Cstdio.printf("[%u]\t%p - 0x%02X\n", i, self.metadata + i, self.metadata[i])
-		end
-	end
-
-	-- Prints a debug view of the table to stdout.
-	terra SM.HashTable:debug_full_repr()
-		Cstdio.printf("HashTable Size: %u, Capacity: %u, OpaquePtr: %p\n", self.size, self.capacity, self.opaque_ptr)
-		for i = 0, self.capacity do
-			Cstdio.printf("[%u]\tMetadata: %p = 0x%02X\tBucket: %p = ", i, self.metadata + i, self.metadata[i], self.buckets + i)
-
-			if self.metadata[i] == 128 then
-				Cstdio.printf("Empty\n", self.buckets + i)
-			elseif self.buckets + i == nil then
-				Cstdio.printf("NULLPTR\n")
-			else
-				-- TODO: this won't work all the time, refactor to handle all types later
-				Cstdio.printf("%s\n", self.buckets[i])
-			end
-		end
-	end
-
-	return SM
-end
-
--- Convienience function that returns a HashTable struct type.
-function M.HashTable(KeyType, HashFn, EqFn, Alloc)
-	local SM = M.CreateHashTableSubModule(KeyType, HashFn, EqFn, Alloc)
-	return SM.HashTable
-end
-
-return M

--- a/hashtable.t
+++ b/hashtable.t
@@ -136,7 +136,7 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 			var index = virtual_index and (capacity -1)
 			var metadata = metadata_array[index]
 
-			if metadata == MetadataEmpty or (metadata == hash_result.h2 and [EqFn](hash.key, buckets_array[index].key)) then
+			if metadata == MetadataEmpty or (metadata == hash.h2 and [EqFn](hash.key, buckets_array[index].key)) then
 				return ProbeResult.ok(index)
 			end
 		end

--- a/hashtable.t
+++ b/hashtable.t
@@ -3,106 +3,111 @@ local O = require 'std.object'
 
 local CStr = terralib.includec("string.h")
 
---[[ Factory function for default hash functions of various types. Generally, the hashing functions outputted are implementation of djb2. ]]--
-local function CreateDefaultHashFunction(KeyType)
-	local function ComputeSize(keyValue)
-		if KeyType == rawstring then
-			return `CStr.strlen(keyValue)
-		else
-			return `sizeof([KeyType])
-		end
+local M = {}
+
+-- Implementation of djb2. Treats all data as a stream of bytes.
+terra M.hash_djb2(data: &int8, size: uint): uint
+	var hash: uint = 5381
+
+	for i = 0, size do
+		hash = ((hash << 5) + hash * 33) + data[i]
 	end
 
-	local terra hash_function(data: KeyType): uint
-		var hash: uint = 5381
-
-		for i = 0, [ComputeSize(data)] do
-			hash = ((hash << 5) + hash * 33) + data[i]
-		end
-
-		return hash
-	end
-
-	return hash_function
+	return hash
 end
 
-local function CreateDefaultEqualityFunction(KeyType)
-	local terra equal_function(k1: KeyType, k2: KeyType): bool
+function M.CreateDefaultHashFunction(KeyType)
+	if KeyType == rawstring then
+		return local terra default_string_hash(str: KeyType)
+			return M.hash_djb2(str, CStr.strlen(str))
+		end
+	-- TODO: Add more cases here
+	else
+		return local terra naive_hash(obj: KeyType)
+			return M.hash_djb2(obj, sizeof(obj))
+		end
+	end
+end
+
+function M.CreateDefaultEqualityFunction(KeyType)
+	-- TODO: Need more cases here too
+	local terra naive_equal_function(1: KeyType, k2: KeyType): bool
 		return k1 == k2
 	end
 	return equal_function
 end
 
---[[ 
-	Creates a new HashTable type.
-
-	This hashtable is based on the dense_hash_set implementation by Google.
---]]
-local function HashTable(KeyType, EqFn, HashFn, Alloc)
-	EqFn = EqFn or CreateDefaultEqualityFunction(KeyType)
-	HashFn = HashFn or CreateDefaultHashFunction(KeyType)
+function M.CreateHashTableSubModule(KeyType, HashFn, EqFn, Alloc)
+	HashFn = HashFn or M.CreateDefaultHashFunction(KeyType)
+	EqFn = EqFn or M.CreateDefaultEqualityFunction(KeyType)
 	Alloc = Alloc or A.default_allocator
 
-	local GroupLength = constant(uint, 16)
+	local SM = {}
 
-	local MetadataHashBitmap = constant(uint8, 127) -- 0b01111111
-	local MetadataEmpty = constant(uint8, 128) -- 0b10000000
+	SM.MetadataHashBitmap = constant(uint8, 127) -- 0b01111111
+	SM.MetadataEmpty = constant(uint8, 128) -- 0b10000000
+	SM.GroupLength = constant(uint, 16)
 
-	local struct Hashtable(O.Object) {
-		-- The total number of buckets in the table.
-		capacity: uint
-		-- The number of items stored in the table
-		size: uint
-		-- Array of bytes holding the metadata of the table.
-		metadata: &uint8
-		-- The backing array of the hashtable.
-		buckets: &KeyType
-	}
 
-	local struct HashResult {
+	-- Produces a collection of methods used for the HashTable implementation.
+	-- This is considered to be an implementation detail and subject to API changes. The only reason this is exposed is for automated testing purposes.
+	SM._Plumbing = {}
+
+	-- Allocates and initalizes memory for the hashtable. The metadata array is initalized to `MetadataEmpty`. Buckets are not initialized to any value.
+	-- Returns a quadruple: The first value is success, the second value is an opaque pointer which should be passed to `free`, the third value is the metadata array, and the forth value is the bucket array.
+	-- Note that if success is false, then all other values are null.
+	terra SM._Plumbing.table_calloc(capacity: uint): tuple(bool, &opaque, &uint8, &KeyType)
+		var opaque_ptr = Alloc:alloc_raw(capacity * (sizeof(KeyType) + 1))
+		
+		if opaque_ptr == nil then
+			return {false, nil, nil, nil}
+		end
+
+		var metadata_array = [&int8](opaque_ptr)
+		var buckets_array = [&KeyType](metadata_array + capacity)
+
+		CStr.memset(metadata_array, SM.MetadataEmpty, capacity)
+
+		return {true, opaque_ptr, metadata_array, buckets_array}
+	end
+		if KeyType == rawstring then
+			return terra default_string_hash(str: KeyType)
+				return M._Plumbing.hash_djb2(str, CStr.strlen(str))
+			end
+		end
+	end
+
+	struct SM._Plumbing.HashResult {
 		initial_bucket_index: uint
 		h1: uint
 		h2: uint8
 	}
 
-	-- Allocates memory large enough to fit the provided number of groups and associated metadata.
-	-- Returns a pointer to the metadata array and a pointer to the bucket array.
-	local terra malloc_by_groups(groups: uint): tuple(&uint8, &KeyType)
-		var buckets = groups * GroupLength
-		var chunk_of_memory = [ Alloc ]:alloc_raw(buckets + (sizeof([KeyType]) * buckets))
-		return { [&uint8] (chunk_of_memory), [&KeyType] ([&uint8] (chunk_of_memory) + GroupLength) }
-	end
-
-	-- Initalizes the metadata array with MetadataEmpty
-	local terra initalize_metadata(metadata_array: &uint8, length: uint)
-		for i = 0, length do
-			metadata_array[i] = MetadataEmpty
-		end
-	end
-
-	local terra compute_hashes(key: KeyType, capacity: uint): HashResult
+	terra SM._Plumbing.compute_hashes(key: KeyType, capacity: uint): SM._Plumbing.HashResult
 		var hash = [ HashFn ](key)
 
 		return HashResult {
 			initial_bucket_index = (hash >> 7) % capacity,
 			h1 = hash >> 7,
-			h2 = hash and MetadataHashBitmap
+			h2 = hash and SM.MetadataHashBitmap
 		}
 	end
 
-	--[[ 
-		Probes the table for the bucket that would contain the key. Capacity should be a power of 2.
-		
-		Returns an index which is only valid for the current state of the table. 
-		This index may point to a bucket which contains the key, or an empty bucket where the key should be inserted if the key does not exist.
-		The return value is negative if an error occured.
-	]]--
-	local terra probe_clever(key: KeyType, hash_result: HashResult, metadata_array: &uint8, buckets: &KeyType, capacity: uint): int
-		for j = hash_result.initial_bucket_index, capacity + hash_result.initial_bucket_index do
-			var i = j and (capacity - 1)
-			var m = metadata_array[i]
+	-- Probes the table for the bucket that would contain the key.
+	-- Expects that capacity is a power of 2.
+	-- Returns an index which is only valid for the current state of the table. The index may point to a bucket which contains an existing key, 
+	-- or to an empty bucket where the key should be inserted if the key does not exist.
+	-- The return value is negative if no bucket can be found.
+	terra SM._Plumbing.probe(key: KeyType,
+							 hash_result: SM._Plumbing.HashResult,
+							 metadata_array: &uint8,
+							 buckets: &KeyType,
+							 capacity: uint): int
+		for virtual_index = hash_result.initial_bucket_index, capacity + hash_result.initial_bucket_index do
+			var index = virtual_index and (capacity -1)
+			var metadata = metadata_array[i]
 
-			if m == MetadataEmpty or (m == hash_result.h2 and [ EqFn ](key, buckets[i])) then
+			if m == SM.MetadataEmpty or (m == hash_result.h2 and [EqFn](key, buckets[i])) then
 				return i
 			end
 		end
@@ -110,67 +115,95 @@ local function HashTable(KeyType, EqFn, HashFn, Alloc)
 		return -1
 	end
 
-	-- Resizes the hashtable by doubling the number of groups.
-	local terra resize_hashtable(hashtable: &Hashtable)
-		var old_group_count = hashtable.capacity / GroupLength
-		var new_group_count = old_group_count * 2
-		var new_capacity = new_group_count * GroupLength
+	SM._Plumbing.probe_table = macro(function(hash_table, key, hash_result)
+		return `SM._Plumbing.probe(key, hash_result, hash_table.metadata, hash_table.buckets, hash_table.capacity)
+	end)
 
-		-- Not using realloc because we need rehash everything.
-		-- That's going to be really hard within the same memory segment
-		var new_metadata, new_buckets = malloc_by_groups(new_group_count)
+	-- Inserts a key into buckets and sets appropriate metadata.
+	-- The reason this is a plumbing function instead of public api is because rehash needs to perform insertions.
+	terra SM._Plumbing.insert(key: KeyType, metadata_array: &uint8, buckets: &KeyType, capacity: uint)
+		var hash_result = SM._Plumbing.compute_hashes(key, capacity)
+		var index = SM._Plumbing.probe(key, hash_result, metadata_array, buckets, capacity)
 
-		initalize_metadata(new_metadata, new_capacity)
+		metadata_array[index] = hash_result.h2
+		buckets[index] = key
+	end
 
-		-- Iterate through the old hashtable and rehash
-		for i = 0, hashtable.capacity do
-			if hashtable.metadata[i] ~= MetadataEmpty then
-				var key = hashtable.buckets[i]
-				var hash_result = compute_hashes(key, new_capacity)
-				var probe_index = probe_clever(key, hash_result, new_metadata, new_buckets, new_capacity)
-
-				new_metadata[probe_index] = hash_result.h2
-				new_buckets[probe_index] = key
+	terra SM._Plumbing.rehash_table(old_metadata: &uint8,
+									old_buckets: &KeyType,
+									old_capacity: uint,
+									new_metadata: &uint8,
+									new_buckets: &KeyType,
+									new_capacity: uint)
+		for i = 0, old_capacity do
+			if old_metadata[i] ~= SM.MetadataEmpty then
+				var key = old_buckets[key]
+				SM._Plumbing.insert(key, new_metadata, new_buckets, new_capacity)
 			end
 		end
+	end
 
-		-- Free old memory
-		[ Alloc ]:free_raw(hashtable.metadata)
+	-- Resizes the hashtable.
+	-- Returns true on success, false otherwise.
+	terra SM._Plumbing.resize_hashtable(hashtable: &SM.HashTable): bool
+		var new_capacity = hashtable.capacity * 2
+		var alloc_success, opaque_ptr, new_metadata, new_buckets = SM._Plumbing.table_calloc(new_capacity)
 
-		hashtable.capacity = new_capacity
+		if alloc_success == false then
+			return false
+
+		SM._Plumbing.rehash_table(hashtable.metadata, hashtable.buckets, hashtable.capacity, new_metadata, new_buckets, new_capacity)
+
+		[Alloc]:free_raw(hashtable.opaque_ptr)
+		hashtable.opaque_ptr = opaque_ptr
 		hashtable.metadata = new_metadata
 		hashtable.buckets = new_buckets
 	end
+	
+	struct SM.HashTable(O.Object) {
+		-- The total number of buckets in the table.
+		capacity: uint
+		-- The number of items stored in the table
+		size: uint
+		-- Pointer to free on destruction
+		opaque_ptr: &opaque
+		-- Array of bytes holding the metadata of the table.
+		metadata: &uint8
+		-- The backing array of the hashtable.
+		buckets: &KeyType
+	}
 
-	terra Hashtable:init()
-		var metadata, buckets = malloc_by_groups(1)
+	terra SM.HashTable:init()
+		var alloc_success, opaque_ptr, metadata, buckets = table_calloc(1)
 		
 		self:_init {
 			capacity = GroupLength,
 			size = 0,
+			opaque_ptr = opaque_ptr,
 			metadata = metadata,
 			buckets = buckets
 		}
-
-		initalize_metadata(self.metadata, self.capacity)
 	end
 
-	terra Hashtable:insert(key: KeyType)
+	terra SM.HashTable:destruct()
+		[Alloc]:free_raw(self.opaque_ptr)
+		self.opaque_ptr = nil
+		self.metadata = nil
+		self.buckets = nil
+	end
+
+	terra SM.HashTable:insert(key: KeyType)
 		if self.size == self.capacity then
 			resize_hashtable(self)
 		end
 
-		var hash_result = compute_hashes(key, self.capacity)
-		var probe_index = probe_clever(key, hash_result, self.metadata, self.buckets, self.capacity)
-
+		SM._Plumbing.insert(key, self.metadata_array, self.buckets, self.capacity)
 		self.size = self.size + 1
-		self.metadata[probe_index] = hash_result.h2
-		self.buckets[probe_index] = key
 	end
 
-	terra Hashtable:has(key: KeyType): bool
+	terra SM.HashTable:has(key: KeyType): bool
 		var hash_result = compute_hashes(key, self.capacity)
-		var probe_index = probe_clever(key, hash_result, self.metadata, self.buckets, self.capacity)
+		var probe_index = SM._Plumbing.probe_tabe(self, key, hash_result)
 
 		if probe_index == -1 or self.metadata[probe_index] == MetadataEmpty then
 			return false
@@ -179,7 +212,13 @@ local function HashTable(KeyType, EqFn, HashFn, Alloc)
 		return true
 	end
 
-	return Hashtable
+	return SM
 end
 
-return HashTable
+-- Convienience function that returns a HashTable struct type.
+function M.HashTable(KeyType, HashFn, EqFn, Alloc)
+	local SM = M.CreateHashTableSubModule(KeyType, HashFn, EqFn, Alloc)
+	return SM.HashTable
+end
+
+return M

--- a/hashtable.t
+++ b/hashtable.t
@@ -264,15 +264,15 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 
 	if IsKeyValue then
 		terra HashTable:insert(key: KeyType, value: ValueType): uint
-			return InsertBody(self, BucketType { key = key, value = value })
+			InsertBody(self, BucketType { key = key, value = value })
 		end
 	else
 		terra HashTable:insert(key: KeyType): uint
-			return InsertBody(self, BucketType { key = key })
+			InsertBody(self, BucketType { key = key })
 		end
 	end
 
-	local DebugTypeInformation = "{ key: " .. tostring(KeyType) .. ( IsKeyValue and ", value: " .. tostring(ValueType)) .. " }"
+	local DebugTypeInformation = "{ key: " .. tostring(KeyType) .. ( IsKeyValue and ", value: " .. tostring(ValueType) or "") .. " }"
 	local DebugHeaderString = "HashTable " .. DebugTypeInformation .. " Size: %u; Capacity: %u; OpaquePtr: %p\n"
 
 	-- Prints a debug view of the metadata array to stdout

--- a/hashtable.t
+++ b/hashtable.t
@@ -120,18 +120,6 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 		return "HashTable[" .. tostring(KeyType) .. (ValueType ~= nil and ", " .. tostring(ValueType) or "") .. "]"
 	end
 
-	function HashTable.metamethods.__for(self, body)
-		return quote
-			var this = self
-			for i = 0, this.capacity do
-				if this.metadata[i] ~= MetadataEmpty then
-					var bucket = this.buckets[i]
-					[body(bucket)]
-				end
-			end
-		end
-	end
-
 	-- Result types
 	local CallocResult = R.MakeResult(tuple(&opaque, &uint8, &BucketType), M.Errors.ErrorType)
 	local ProbeResult = R.MakeResult(uint, M.Errors.ErrorType)

--- a/hashtable.t
+++ b/hashtable.t
@@ -344,9 +344,13 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 		return Entry { self, hash_info, probe_index }
 	end
 
+	terra Entry:is_empty(): bool
+		return self.hash_table.metadata[self.index] == MetadataEmpty
+	end
+
 	if BucketType.IsKeyValue then
-		terra Entry:insert_or(value: ValueType): ValueType
-			if (self.hash_table.metadata[self.index] == MetadataEmpty) then
+		terra Entry:or_insert(value: ValueType): ValueType
+			if (self:is_empty()) then
 				self.hash_table.metadata[self.index] = self.hash_info.h2
 				self.hash_table.buckets[self.index] = BucketType { self.hash_info.key, value }
 				self.hash_table.size = self.hash_table.size + 1
@@ -355,8 +359,8 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 			return self.buckets[self.index].value
 		end
 	else
-		terra Entry:insert_or(): KeyType
-			if (self.hash_table.metadata[self.index] == MetadataEmpty) then
+		terra Entry:or_insert(): KeyType
+			if (self:is_empty()) then
 				self.hash_table.metadata[self.index] = self.hash_info.h2
 				self.hash_table.buckets[self.index] = BucketType { self.hash_info.key }
 				self.hash_table.size = self.hash_table.size + 1

--- a/hashtable.t
+++ b/hashtable.t
@@ -279,6 +279,7 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 			
 			self.metadata[index] = MetadataEmpty
 			CStr.memset(self.buckets + index, 0, sizeof(BucketType))
+			self.size = self.size - 1
 			
 			return RemoveResult.ok(bucket)
 		end

--- a/hashtable.t
+++ b/hashtable.t
@@ -3,7 +3,7 @@ local O = require 'std.object'
 
 local CStr = terralib.includec("string.h")
 
---[[ Factory function for default hash functions of various types. Generally, the hasing functions outputted are implementation of djb2. ]]--
+--[[ Factory function for default hash functions of various types. Generally, the hashing functions outputted are implementation of djb2. ]]--
 function CreateDefaultHashFunction(KeyType)
 	local function ComputeSize(keyValue)
 		if KeyType == rawstring then
@@ -31,44 +31,56 @@ end
 
 	This hashtable is based on the dense_hash_set implementation by Google.
 --]]
-function HashTable(Key, HashFn, GroupLength, Alloc)
-	HashFn = HashFn or CreateDefaultHashFunction(Key)
-	GroupLength = GroupLength or 48
+function HashTable(KeyType, HashFn, Alloc)
+	HashFn = HashFn or CreateDefaultHashFunction(KeyType)
 	Alloc = Alloc or A.default_allocator
 
-	local MetadataHashBitmap = constant(127) -- 0b01111111
-	local MetadataEmpty = constant(128) -- 0b10000000
+	local GroupLength = constant(uint, 16)
 
-	local struct Entry {
-		-- A pointer to the metadata byte.
-		metadata: &int8
-
-		-- A pointer to the bucket.
-		bucket: &Key
-	}
+	local MetadataHashBitmap = constant(uint8, 127) -- 0b01111111
+	local MetadataEmpty = constant(uint8, 128) -- 0b10000000
 
 	local struct Hashtable(O.Object) {
 		-- The total number of buckets in the table.
 		capacity: uint
+		-- The number of items stored in the table
+		size: uint
 		-- Array of bytes holding the metadata of the table.
 		metadata: &int8
 		-- The backing array of the hashtable.
-		buckets: &Key
+		buckets: &KeyType
+	}
+
+	local struct HashResult {
+		bucket_index: uint
+		h1: uint
+		h2: uint8
 	}
 
 	-- Allocates memory large enough to fit the provided number of groups and associated metadata. Returns a pointer to this block of memory.
 	local terra malloc_by_groups(groups: uint): &opaque
-		var buckets = groups * [ GroupLength ]
-		return [ Alloc ]:alloc_raw(buckets + (sizeof([Key]) * buckets))
+		var buckets = groups * GroupLength
+		return [ Alloc ]:alloc_raw(buckets + (sizeof([KeyType]) * buckets))
+	end
+
+	local terra compute_hashes(capacity: uint, key: KeyType): HashResult
+		var hash = [ HashFn ](key)
+
+		return HashResult {
+			bucket_index = (hash >> 7) % capacity,
+			h1 = hash >> 7,
+			h2 = hash and MetadataHashBitmap
+		}
 	end
 
 	terra Hashtable:init()
 		var big_ol_chunk_of_memory = malloc_by_groups(1)
 		
 		self:_init {
-			capacity = [ GroupLength ],
+			capacity = GroupLength,
+			size = 0,
 			metadata = [&int8] (big_ol_chunk_of_memory),
-			buckets =  [&Key] ( [&int8] (big_ol_chunk_of_memory) + [ GroupLength ])
+			buckets =  [&KeyType] ( [&int8] (big_ol_chunk_of_memory) + GroupLength)
 		}
 
 		-- Initialize the metadata array
@@ -77,22 +89,12 @@ function HashTable(Key, HashFn, GroupLength, Alloc)
 		end
 	end
 
-	terra Hashtable:insert(key: Key)
-		var hash = [ HashFn ](key)
-		var bucket_index = hash % self.capacity
+	terra Hashtable:insert(key: KeyType)
+		var hash_result = compute_hashes(self.capacity, key)
 
-		self.metadata[bucket_index] = hash and MetadataHashBitmap
-		self.buckets[bucket_index] = key
-	end
-
-	terra Hashtable:entry(key: Key): Entry
-		var hash = [ HashFn ](key)
-		var bucket_index = hash % self.capacity
-		
-		return Entry {
-			metadata = self.metadata + bucket_index,
-			bucket = self.buckets + bucket_index
-		}
+		self.size = self.size + 1
+		self.metadata[hash_result.bucket_index] = hash_result.h2
+		self.buckets[hash_result.bucket_index] = key
 	end
 
 	return Hashtable

--- a/hashtable.t
+++ b/hashtable.t
@@ -293,7 +293,7 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 			var hash_info, index = result.ok
 
 			if self.metadata[index] ~= MetadataEmpty then
-				self.metadata[index] == MetadataEmpty
+				self.metadata[index] = MetadataEmpty
 				CStr.memset(self.buckets + index, 0, sizeof(BucketType))
 			end
 
@@ -340,7 +340,7 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 				if self.metadata[index] == MetadataEmpty then
 					return GetResult.err(M.Errors.NotFound)
 				else
-					return GetResult.ok(self.buckets[index])
+					return GetResult.ok(self.buckets[index].value)
 				end
 			else
 				return GetResult.err(result.err)

--- a/hashtable.t
+++ b/hashtable.t
@@ -17,8 +17,8 @@ local M = {}
 M.CTHashTable = CT.All(
 	CT.Field("capacity", CT.Integral),
 	CT.Field("size", CT.Integral),
-	CT.Method("resize", CT.Empty, CT.Integral),
-	CT.MetaConstraint(
+	CT.Method("resize", CT.Empty, CT.Integral)
+	--[[CT.MetaConstraint(
 		function(KeyType, ValueType, HandleType)
 			local lookup_constraint = CT.Method("lookup_handle", CT.Type(KeyType), CT.Type(HandleType))
 			-- This is just a tuple of (KeyType, ValueType)
@@ -38,12 +38,26 @@ M.CTHashTable = CT.All(
 			return CT.All(lookup_constraint, store_constraint, retrieve_constraint)
 		end,
 		CT.TerraType, CT.TerraType, CT.TerraType
-	)
+	)]]--
 )
+
+local function MakeHashFunctionConstraint(KeyType, HashType)
+	return CT.Function({KeyType}, HashType)
+end
+
+local function MakeEqualityFunctionConstraint(KeyType)
+	return CT.Function({KeyType, KeyType}, bool)
+end
 
 M.Implementation = {}
 
 function M.Implementation.DenseHashTable(KeyType, ValueType, HashFn, EqFn, Alloc)
+	-- TODO: Rework this
+	local CTHashFn = MakeHashFunctionConstraint(KeyType, uint)
+	local CTEqFn = MakeEqualityFunctionConstraint(KeyType)
+	CTHashFn(HashFn)
+	CTEqFn(EqFn)
+
 	local MetadataHashBitmap = constant(uint8, 127) -- 0b01111111
 	local MetadataEmpty = constant(uint8, 128) -- 0b10000000
 	local GroupLength = constant(uint, 16)

--- a/hashtable.t
+++ b/hashtable.t
@@ -172,10 +172,11 @@ function M.CreateHashTableSubModule(KeyType, HashFn, EqFn, Alloc)
 	}
 
 	terra SM.HashTable:init()
-		var alloc_success, opaque_ptr, metadata, buckets = SM._Plumbing.table_calloc(1)
+		var initial_capacity = SM.GroupLength
+		var alloc_success, opaque_ptr, metadata, buckets = SM._Plumbing.table_calloc(initial_capacity)
 		
 		self:_init {
-			capacity = SM.GroupLength,
+			capacity = initial_capacity,
 			size = 0,
 			opaque_ptr = opaque_ptr,
 			metadata = metadata,
@@ -214,10 +215,19 @@ function M.CreateHashTableSubModule(KeyType, HashFn, EqFn, Alloc)
 		return true
 	end
 
-	-- Prints a debug view of the table to stdout.
-	terra SM.HashTable:debug_repr()
+	-- Prints a debug view of the metadata array to stdout
+	terra SM.HashTable:debug_metadata_repr()
+		Cstdio.printf("HashTable Size: %u, Capacity: %u, OpaquePtr: %p\n", self.size, self.capacity, self.opaque_ptr)
 		for i = 0, self.capacity do
-			Cstdio.printf("[%u]\t%p\t0x%X\t%p\t", i, self.metadata + i, self.metadata[i], self.buckets + i)
+			Cstdio.printf("[%u]\t%p - 0x%02X\n", i, self.metadata + i, self.metadata[i])
+		end
+	end
+
+	-- Prints a debug view of the table to stdout.
+	terra SM.HashTable:debug_full_repr()
+		Cstdio.printf("HashTable Size: %u, Capacity: %u, OpaquePtr: %p\n", self.size, self.capacity, self.opaque_ptr)
+		for i = 0, self.capacity do
+			Cstdio.printf("[%u]\tMetadata: %p = 0x%02X\tBucket: %p - ", i, self.metadata + i, self.metadata[i], self.buckets + i)
 
 			if self.metadata[i] == 128 then
 				Cstdio.printf("Empty\n", self.buckets + i)

--- a/hashtable.t
+++ b/hashtable.t
@@ -51,7 +51,6 @@ function M.CreateHashTableSubModule(KeyType, HashFn, EqFn, Alloc)
 	SM.MetadataEmpty = constant(uint8, 128) -- 0b10000000
 	SM.GroupLength = constant(uint, 16)
 
-
 	-- Produces a collection of methods used for the HashTable implementation.
 	-- This is considered to be an implementation detail and subject to API changes. The only reason this is exposed is for automated testing purposes.
 	SM._Plumbing = {}
@@ -227,7 +226,7 @@ function M.CreateHashTableSubModule(KeyType, HashFn, EqFn, Alloc)
 	terra SM.HashTable:debug_full_repr()
 		Cstdio.printf("HashTable Size: %u, Capacity: %u, OpaquePtr: %p\n", self.size, self.capacity, self.opaque_ptr)
 		for i = 0, self.capacity do
-			Cstdio.printf("[%u]\tMetadata: %p = 0x%02X\tBucket: %p - ", i, self.metadata + i, self.metadata[i], self.buckets + i)
+			Cstdio.printf("[%u]\tMetadata: %p = 0x%02X\tBucket: %p = ", i, self.metadata + i, self.metadata[i], self.buckets + i)
 
 			if self.metadata[i] == 128 then
 				Cstdio.printf("Empty\n", self.buckets + i)

--- a/hashtable.t
+++ b/hashtable.t
@@ -1,10 +1,290 @@
 local A = require 'std.alloc'
-local O = require 'std.object' 
+local O = require 'std.object'
+local CT = require 'std.constraint'
 
 local CStr = terralib.includec("string.h")
 local Cstdio = terralib.includec("stdio.h")
 
 local M = {}
+
+-- Defines a low-level generic HashTable interface.
+-- capacity = A field with an integer type that defines the capacity of the container.
+-- size = A field with an integer type that defines the number of items in the contianer. Should always be less than or equal to capacity.
+-- resize = A method that expands the capacity of the container. Returns 0 on success.
+-- lookup_handle = A method that takes its a key and it's hash and returns a handle which refers to a location in the container that can be used for storage or retrevial.
+-- store_handle = A method which takes a key (and a value if its a key/value store), and a Handle, and stores the item at the location. Returns 0 on success.
+-- retrieve_handle = A method that takes a handle and returns the key or key and value at the location. May return null on failure.
+M.CTHashTable = CT.All(
+	CT.Field("capacity", CT.Integral),
+	CT.Field("size", CT.Integral),
+	CT.Method("resize", nil, CT.Integral),
+	CT.MetaConstraint(
+		function(KeyType, ValueType, HandleType)
+			local lookup_constraint = CT.Method("lookup_handle", CT.Type(KeyType), CT.Type(HandleType)),
+			
+			if ValueType ~= nil then
+				local store_constraint = CT.Method("store_handle", {CT.Type(HandleType), CT.Type(KeyType), CT.Type(ValueType)}, CT.Integral)
+				local retreive_constraint = CT.Method("retrieve_handle", CT.Type(HandleType), {CT.Type(KeyType), CT.Type(ValueType)})
+			else
+				local store_constraint = CT.Method("store_handle", {CT.Type(HandleType), CT.Type(KeyType)}, CT.Integral)
+				local retreive_constraint = CT.Method("retrieve_handle", CT.Type(HandleType), CT.Type(KeyType))
+			end
+
+			return CT.All(lookup_constraint, insert_constraint, retrieve_handle)
+		end,
+		CT.TerraType, CT.TerraType, CT.TerraType
+	)
+)
+
+M.Implementation = {}
+
+function M.Implementation.DenseHashTable(KeyType, ValueType, HashFn, EqFn, Alloc)
+	MetadataHashBitmap = constant(uint8, 127) -- 0b01111111
+	MetadataEmpty = constant(uint8, 128) -- 0b10000000
+	GroupLength = constant(uint, 16)
+
+	if ValueType == nil then
+		local BucketType = KeyType
+		local IsKeyEq = macro(function(key, bucket)
+			return `EqFn(key, bucket)
+		end)
+	else
+		local BucketType = struct {
+			key: KeyType
+			value: ValueType
+		}
+		local IsKeyEq = macro(function(key, bucket)
+			return `EqFn(key, bucket.value)
+		end)
+	end
+
+	-- Allocates and initalizes memory for the hashtable. The metadata array is initalized to `MetadataEmpty`. Buckets are not initialized to any value.
+	-- Returns a quadruple: The first value is success, the second value is an opaque pointer which should be passed to `free`, the third value is the metadata array, and the forth value is the bucket array.
+	-- Note that if success is false, then all other values are null.
+	local terra table_calloc(capacity: uint): tuple(bool, &opaque, &uint8, &BucketType)
+		var opaque_ptr = Alloc:alloc_raw(capacity * (sizeof(BucketType) + 1))
+		
+		if opaque_ptr == nil then
+			return {false, nil, nil, nil}
+		end
+
+		var metadata_array = [&uint8](opaque_ptr)
+		var buckets_array = [&BucketType](metadata_array + capacity)
+
+		CStr.memset(metadata_array, MetadataEmpty, capacity)
+
+		return {true, opaque_ptr, metadata_array, buckets_array}
+	end
+
+	local struct HashResult {
+		initial_bucket_index: uint
+		h1: uint
+		h2: uint8
+	}
+
+	local struct BucketHandle {
+		iserror: bool
+		index: uint
+		hash_result: HashResult
+	}
+
+	local terra compute_hash(key: KeyType, capacity: uint): HashResult
+		var hash = [ HashFn ](key)
+
+		return SM.HashResult {
+			initial_bucket_index = (hash >> 7) % capacity,
+			h1 = hash >> 7,
+			h2 = hash and SM.MetadataHashBitmap
+		}
+	end
+
+	struct DenseHashTable(O.Object) {
+		-- The total number of buckets in the table.
+		capacity: uint
+		-- The number of items stored in the table
+		size: uint
+		-- Pointer to free on destruction
+		opaque_ptr: &opaque
+		-- Array of bytes holding the metadata of the table.
+		metadata: &uint8
+		-- The backing array of the hashtable.
+		buckets: &BucketType
+	}
+
+	-- Assigns all the fields of the hashtable to the specified values.
+	-- This is done because I'm not sure if I can reuse "self:_init" and we need saftey when mangling the internals in resize.
+	terra reassign_internals(htable: DenseHashTable, capacity: uint, size: uint, opaque_ptr: &opaque, metadata: &uint8, buckets: &BucketType)
+		htable.capacity = capacity
+		htable.size = size
+		htable.opaque_ptr = opaque_ptr
+		htable.metadata = metadata
+		htable.buckets = buckets
+	end
+
+	terra DenseHashTable:init()
+		var alloc_success, opaque_ptr, metadata, buckets = table_calloc(initial_capacity)
+
+		self:_init {
+			capacity = GroupLength,
+			size = 0,
+			opaque_ptr = opaque_ptr,
+			metadata = metadata,
+			buckets = buckets,
+			entries = nil
+		}
+	end
+
+	terra DenseHashTable:destruct()
+		if self.opaque_ptr ~= nil then
+			[Alloc]:free_raw(self.opaque_ptr)
+		end
+
+		CStr.memset(self, 0, sizeof(SM.HashTable)
+	end
+
+	terra DenseHashTable:lookup_handle(key: KeyType): BucketHandle 
+		var hash_result = compute_hash(key, self.capacity)
+		var virtual_limit = self.capacity + hash_result.initial_bucket_index
+
+		for virtual_index = hash_result.initial_bucket_index, virtual_limit do
+			var index = virtual_index and (capacity - 1)
+			var metadata = self.metadata[index]
+
+			if metadata == SM.MetadataEmpty or (metadata == hash_result.h2 and IsKeyEq(key, self.buckets[index])) then
+				return BucketHandle {false, index, hash_result}
+			end
+		end
+
+		return BucketHandle {true, -1, nil}
+	end
+
+	local StoreHandleBody = macro(function(self, handle, key, value) 
+		return quote
+			if [handle].iserror then
+				return [handle].index
+			end
+
+			var index = [handle].index
+			var hash_result = [handle].hash_result
+			var previous_metadata = self.metadata[index]	
+
+			[self].metadata[index] = hash_result.h2
+			[self].buckets[index] = escape
+				if ValueType ~= nil then
+					emit(`BucketType { key = [key], value = [value])
+				else
+					emit(`key)
+				end
+			end
+
+			if previous_metadata == MetadataEmpty then
+				[self].size = [self].size + 1
+			end
+
+			return 0
+		end
+	end)
+
+	if ValueType ~= nil then
+		terra DenseHashTable:store_handle(handle: BucketHandle, key: KeyType, value: ValueType): int
+			StoreHandleBody(self, handle, key, value)
+		end
+
+		terra DenseHashTable:retrieve_handle(handle: BucketHandle): tuple(KeyType, ValueType)
+			if handle.iserror then
+				return nil
+			end
+			
+			var bucket = self.buckets[handle.index]
+			return { bucket.key, bucket.value }
+		end
+	else
+		terra DenseHashTable:store_handle(handle: BucketHandle, key: KeyType): int
+			StoreHandleBody(self, handle, key)
+		end
+
+		terra DenseHashTable:retrieve_handle(handle: BucketHandle): KeyType
+			if handle.iserror then
+				return nil
+			end
+
+			return self.buckets[handle.index]
+		end
+	end
+
+	terra DenseHashTable:resize(): int
+		var old_size = self.size
+		var old_capacity = self.capacity
+		var old_opaque_ptr = self.opaque_ptr
+		var old_metadata = self.metadata
+		var old_buckets = self.buckets
+
+		var new_capacity = self.capacity * 2
+		var alloc_success, new_opaque_ptr, new_metadata, new_buckets = table_calloc(new_capacity)
+
+		if ~alloc_success then
+			return -1
+		end
+
+		reassign_internals(self, new_capacity, 0, new_opaque_ptr, new_metadata, new_buckets)
+
+		for i = 0, old_capacity do
+			if metadata[i] ~= MetadataEmpty then
+				var old_bucket: BucketType = self.old_buckets[i]
+				escape
+					if ValueType ~= nil then
+						emit(quote
+							var handle = self:lookup_handle(old_bucket.key)
+							var result = self:store_handle(handle, old_bucket.key, old_bucket.value)
+						end)
+					else
+						emit(quote
+							var handle = self.lookup_handle(old_bucket)
+							var result = self:store_handle(handle, old_bucket)
+						end)
+					end
+				end
+
+				if result != 0 then
+					-- An error occured when rehashing. Reset the state of the hashtable and return an error.
+					reassign_internals(self, old_capacity, old_size, old_opaque_ptr, old_metadata, old_buckets)
+					[Alloc]:free(new_opaque_ptr)
+					return 1
+				end
+			end
+		end
+
+		-- Free old data
+		[Alloc]:free(old_opaque_ptr)
+
+		return 0
+	end
+
+	-- Prints a debug view of the metadata array to stdout
+	terra DenseHashTable:_debug_metadata_repr()
+		Cstdio.printf("HashTable Size: %u, Capacity: %u, OpaquePtr: %p\n", self.size, self.capacity, self.opaque_ptr)
+		for i = 0, self.capacity do
+			Cstdio.printf("[%u]\t%p - 0x%02X\n", i, self.metadata + i, self.metadata[i])
+		end
+	end
+
+	-- Prints a debug view of the table to stdout.
+	terra SM.HashTable:debug_full_repr()
+		Cstdio.printf("HashTable Size: %u, Capacity: %u, OpaquePtr: %p\n", self.size, self.capacity, self.opaque_ptr)
+		for i = 0, self.capacity do
+			Cstdio.printf("[%u]\tMetadata: %p = 0x%02X\tBucket: %p = ", i, self.metadata + i, self.metadata[i], self.buckets + i)
+
+			if self.metadata[i] == 128 then
+				Cstdio.printf("Empty\n", self.buckets + i)
+			elseif self.buckets + i == nil then
+				Cstdio.printf("NULLPTR\n")
+			else
+				-- TODO: this won't work all the time, refactor to handle all types later
+				Cstdio.printf("%s\n", self.buckets[i])
+			end
+		end
+	end
+end
 
 -- Implementation of djb2. Treats all data as a stream of bytes.
 terra M.hash_djb2(data: &int8, size: uint): uint
@@ -38,217 +318,6 @@ function M.CreateDefaultEqualityFunction(KeyType)
 		return k1 == k2
 	end
 	return naive_equal_function
-end
-
-function M.CreateHashTableSubModule(KeyType, HashFn, EqFn, Alloc)
-	HashFn = HashFn or M.CreateDefaultHashFunction(KeyType)
-	EqFn = EqFn or M.CreateDefaultEqualityFunction(KeyType)
-	Alloc = Alloc or A.default_allocator
-
-	local SM = {}
-
-	SM.MetadataHashBitmap = constant(uint8, 127) -- 0b01111111
-	SM.MetadataEmpty = constant(uint8, 128) -- 0b10000000
-	SM.GroupLength = constant(uint, 16)
-
-	-- Produces a collection of methods used for the HashTable implementation.
-	-- This is considered to be an implementation detail and subject to API changes. The only reason this is exposed is for automated testing purposes.
-	SM._Plumbing = {}
-
-	-- Allocates and initalizes memory for the hashtable. The metadata array is initalized to `MetadataEmpty`. Buckets are not initialized to any value.
-	-- Returns a quadruple: The first value is success, the second value is an opaque pointer which should be passed to `free`, the third value is the metadata array, and the forth value is the bucket array.
-	-- Note that if success is false, then all other values are null.
-	terra SM._Plumbing.table_calloc(capacity: uint): tuple(bool, &opaque, &uint8, &KeyType)
-		var opaque_ptr = Alloc:alloc_raw(capacity * (sizeof(KeyType) + 1))
-		
-		if opaque_ptr == nil then
-			return {false, nil, nil, nil}
-		end
-
-		var metadata_array = [&uint8](opaque_ptr)
-		var buckets_array = [&KeyType](metadata_array + capacity)
-
-		CStr.memset(metadata_array, SM.MetadataEmpty, capacity)
-
-		return {true, opaque_ptr, metadata_array, buckets_array}
-	end
-
-	struct SM._Plumbing.HashResult {
-		initial_bucket_index: uint
-		h1: uint
-		h2: uint8
-	}
-
-	terra SM._Plumbing.compute_hashes(key: KeyType, capacity: uint): SM._Plumbing.HashResult
-		var hash = [ HashFn ](key)
-
-		return SM._Plumbing.HashResult {
-			initial_bucket_index = (hash >> 7) % capacity,
-			h1 = hash >> 7,
-			h2 = hash and SM.MetadataHashBitmap
-		}
-	end
-
-	-- Probes the table for the bucket that would contain the key.
-	-- Expects that capacity is a power of 2.
-	-- Returns an index which is only valid for the current state of the table. The index may point to a bucket which contains an existing key, 
-	-- or to an empty bucket where the key should be inserted if the key does not exist.
-	-- The return value is negative if no bucket can be found.
-	terra SM._Plumbing.probe(key: KeyType,
-							 hash_result: SM._Plumbing.HashResult,
-							 metadata_array: &uint8,
-							 buckets: &KeyType,
-							 capacity: uint): int
-		for virtual_index = hash_result.initial_bucket_index, capacity + hash_result.initial_bucket_index do
-			var index = virtual_index and (capacity -1)
-			var metadata = metadata_array[index]
-
-			if metadata == SM.MetadataEmpty or (metadata == hash_result.h2 and [EqFn](key, buckets[index])) then
-				return index
-			end
-		end
-
-		return -1
-	end
-
-	SM._Plumbing.probe_table = macro(function(hash_table, key, hash_result)
-		return `SM._Plumbing.probe(key, hash_result, hash_table.metadata, hash_table.buckets, hash_table.capacity)
-	end)
-
-	-- Inserts a key into buckets and sets appropriate metadata.
-	-- The reason this is a plumbing function instead of public api is because rehash needs to perform insertions.
-	terra SM._Plumbing.insert(key: KeyType, metadata_array: &uint8, buckets: &KeyType, capacity: uint)
-		var hash_result = SM._Plumbing.compute_hashes(key, capacity)
-		var index = SM._Plumbing.probe(key, hash_result, metadata_array, buckets, capacity)
-
-		metadata_array[index] = hash_result.h2
-		buckets[index] = key
-	end
-
-	terra SM._Plumbing.rehash_table(old_metadata: &uint8,
-									old_buckets: &KeyType,
-									old_capacity: uint,
-									new_metadata: &uint8,
-									new_buckets: &KeyType,
-									new_capacity: uint)
-		for i = 0, old_capacity do
-			if old_metadata[i] ~= SM.MetadataEmpty then
-				var key = old_buckets[i]
-				SM._Plumbing.insert(key, new_metadata, new_buckets, new_capacity)
-			end
-		end
-	end
-
-	-- Resizes the hashtable.
-	-- Returns true on success, false otherwise.
-	terra SM._Plumbing.resize_hashtable(hashtable: &SM.HashTable): bool
-		var new_capacity = hashtable.capacity * 2
-		var alloc_success, opaque_ptr, new_metadata, new_buckets = SM._Plumbing.table_calloc(new_capacity)
-
-		if alloc_success == false then
-			return false
-		end
-
-		SM._Plumbing.rehash_table(hashtable.metadata, hashtable.buckets, hashtable.capacity, new_metadata, new_buckets, new_capacity)
-
-		[Alloc]:free_raw(hashtable.opaque_ptr)
-		hashtable.opaque_ptr = opaque_ptr
-		hashtable.metadata = new_metadata
-		hashtable.buckets = new_buckets
-		hashtable.capacity = new_capacity
-
-		return true
-	end
-	
-	struct SM.HashTable(O.Object) {
-		-- The total number of buckets in the table.
-		capacity: uint
-		-- The number of items stored in the table
-		size: uint
-		-- Pointer to free on destruction
-		opaque_ptr: &opaque
-		-- Array of bytes holding the metadata of the table.
-		metadata: &uint8
-		-- The backing array of the hashtable.
-		buckets: &KeyType
-	}
-
-	terra SM.HashTable:init()
-		var initial_capacity = SM.GroupLength
-		var alloc_success, opaque_ptr, metadata, buckets = SM._Plumbing.table_calloc(initial_capacity)
-		
-		self:_init {
-			capacity = initial_capacity,
-			size = 0,
-			opaque_ptr = opaque_ptr,
-			metadata = metadata,
-			buckets = buckets
-		}
-	end
-
-	terra SM.HashTable:destruct()
-		[Alloc]:free_raw(self.opaque_ptr)
-		self.opaque_ptr = nil
-		self.metadata = nil
-		self.buckets = nil
-		self.size = 0
-		self.capacity = 0
-	end
-
-	-- Inserts the key into the table. If the table is full, a resize is triggered.
-	terra SM.HashTable:insert(key: KeyType)
-		if self.size == self.capacity then
-			SM._Plumbing.resize_hashtable(self)
-		end
-
-		SM._Plumbing.insert(key, self.metadata, self.buckets, self.capacity)
-		self.size = self.size + 1
-	end
-
-	-- Tests if the table has a key of the specified value. Returns true if a value exists, false otherwise.
-	terra SM.HashTable:has(key: KeyType): bool
-		var hash_result = SM._Plumbing.compute_hashes(key, self.capacity)
-		var probe_index = SM._Plumbing.probe_table(self, key, hash_result)
-
-		if probe_index == -1 or self.metadata[probe_index] == SM.MetadataEmpty then
-			return false
-		end
-
-		return true
-	end
-
-	-- Prints a debug view of the metadata array to stdout
-	terra SM.HashTable:debug_metadata_repr()
-		Cstdio.printf("HashTable Size: %u, Capacity: %u, OpaquePtr: %p\n", self.size, self.capacity, self.opaque_ptr)
-		for i = 0, self.capacity do
-			Cstdio.printf("[%u]\t%p - 0x%02X\n", i, self.metadata + i, self.metadata[i])
-		end
-	end
-
-	-- Prints a debug view of the table to stdout.
-	terra SM.HashTable:debug_full_repr()
-		Cstdio.printf("HashTable Size: %u, Capacity: %u, OpaquePtr: %p\n", self.size, self.capacity, self.opaque_ptr)
-		for i = 0, self.capacity do
-			Cstdio.printf("[%u]\tMetadata: %p = 0x%02X\tBucket: %p = ", i, self.metadata + i, self.metadata[i], self.buckets + i)
-
-			if self.metadata[i] == 128 then
-				Cstdio.printf("Empty\n", self.buckets + i)
-			elseif self.buckets + i == nil then
-				Cstdio.printf("NULLPTR\n")
-			else
-				-- TODO: this won't work all the time, refactor to handle all types later
-				Cstdio.printf("%s\n", self.buckets[i])
-			end
-		end
-	end
-
-	return SM
-end
-
--- Convienience function that returns a HashTable struct type.
-function M.HashTable(KeyType, HashFn, EqFn, Alloc)
-	local SM = M.CreateHashTableSubModule(KeyType, HashFn, EqFn, Alloc)
-	return SM.HashTable
 end
 
 return M

--- a/hashtable.t
+++ b/hashtable.t
@@ -284,6 +284,8 @@ function M.Implementation.DenseHashTable(KeyType, ValueType, HashFn, EqFn, Alloc
 			end
 		end
 	end
+
+	return DenseHashTable
 end
 
 -- Implementation of djb2. Treats all data as a stream of bytes.

--- a/hashtable.t
+++ b/hashtable.t
@@ -1,332 +1,10 @@
 local A = require 'std.alloc'
-local O = require 'std.object'
-local CT = require 'std.constraint'
-local R = require 'std.result'
+local O = require 'std.object' 
 
 local CStr = terralib.includec("string.h")
 local Cstdio = terralib.includec("stdio.h")
 
 local M = {}
-
-M.Implementation = {}
-
-function M.Implementation.BucketType(KeyType, ValueType)
-	local BucketTypeMeta = {}
-
-	function BucketTypeMeta:__tostring()
-		local tag_section = "Tag: " .. self.Tag
-		local key_section = "KeyType: " .. tostring(self.KeyType)
-		local value_section = "ValueType: " .. (tostring(self.ValueType) or "nil")
-
-		return "BucketType { " .. tag_section .. ", " .. key_section .. ", " .. value_section .. " }"
-	end
-
-	local BucketType = (ValueType ~= nil) and
-		{ KeyType = KeyType, ValueType = ValueType, TerraType = struct { key: KeyType value: ValueType }, Tag = "StructType" } or
-		{ KeyType = KeyType, ValueType = nil, TerraType = KeyType, Tag = "KeyType" }
-	
-	setmetatable(BucketType, BucketTypeMeta)
-
-	function BucketType:Choose(S, K)
-		if self.Tag == "StructType" then
-			return S
-		else
-			return K
-		end
-	end
-
-	function BucketType:ChooseFn(SFn, KFn, ...)
-		return self:Choose(SFn, KFn)(...)
-	end
-
-	function BucketType:Match(StructCase, KeyCase)
-		return self:ChooseFn(StructCase, KeyCase, self)
-	end
-
-	function BucketType:CreateBucket(key, value)
-		return self:ChooseFn(function() return `[self.TerraType] {[key], [value]} end, function() return key end)
-	end
-
-	function BucketType:GetKey(bucket)
-		return self:ChooseFn(function() return `[bucket].key end, function() return bucket end)
-	end
-
-	return BucketType
-end
-
-function M.Implementation.DenseHashTable(BucketType, HashFn, EqFn, Alloc)
-	local MetadataHashBitmap = constant(uint8, 127) -- 0b01111111
-	local MetadataEmpty = constant(uint8, 128) -- 0b10000000
-	local GroupLength = constant(uint, 16)
-
-	local CreateBucket = macro(function (key, value) return BucketType:CreateBucket(key, value) end)
-	local GetBucketKey = macro(function (bucket) return BucketType:GetKey(bucket) end)
-	local IsKeyEq = macro(function(key, bucket)
-		return `[EqFn]([key], GetBucketKey(bucket))
-	end)
-
-	local struct DenseHashTable(O.Object) {
-		-- The total number of buckets in the table.
-		capacity: uint
-		-- The number of items stored in the table
-		size: uint
-		-- Pointer to free on destruction
-		opaque_ptr: &opaque
-		-- Array of bytes holding the metadata of the table.
-		metadata: &uint8
-		-- The backing array of the hashtable.
-		buckets: &BucketType.TerraType
-	}
-
-	local struct HashResult {
-		initial_bucket_index: uint
-		h1: uint
-		h2: uint8
-	}
-
-	local struct BucketIndex {
-		index: uint
-		hash_result: HashResult
-	}
-
-	-- A triple containing an opaque pointer to pass to `free`, a pointer to a metadata array, and a pointer to a bucket array
-	local CallocResult = R.MakeResult(tuple(&opaque, &uint8, &BucketType.TerraType), int) 
-	-- Return value of lookup_handle 
-	local BucketHandle = R.MakeResult(BucketIndex, int)
-	-- Return value of retrieve_handle
-	local RetrieveResult = R.MakeResult(BucketType:Match(
-		function(StructCase) return tuple(StructCase.KeyType, StructCase.ValueType) end,
-		function(KeyCase) return KeyCase.KeyType end), int)
-
-	-- Allocates and initalizes memory for the hashtable. The metadata array is initalized to `MetadataEmpty`. Buckets are not initialized to any value.
-	local terra table_calloc(capacity: uint): CallocResult 
-		var opaque_ptr = Alloc:alloc_raw(capacity * (sizeof(BucketType.TerraType) + 1))
-		
-		if opaque_ptr == nil then
-			return CallocResult.err(1)
-		end
-
-		var metadata_array = [&uint8](opaque_ptr)
-		var buckets_array = [&BucketType.TerraType](metadata_array + capacity)
-
-		CStr.memset(metadata_array, MetadataEmpty, capacity)
-
-		return CallocResult.ok{opaque_ptr, metadata_array, buckets_array}
-	end
-
-	local terra compute_hash(key: BucketType.KeyType, capacity: uint): HashResult
-		var hash = [ HashFn ](key)
-
-		return HashResult {
-			initial_bucket_index = (hash >> 7) % capacity,
-			h1 = hash >> 7,
-			h2 = hash and MetadataHashBitmap
-		}
-	end
-
-	-- Assigns all the fields of the hashtable to the specified values.
-	-- This is done because I'm not sure if I can reuse "self:_init" and we need saftey when mangling the internals in resize.
-	local terra reassign_internals(htable: &DenseHashTable, capacity: uint, size: uint, opaque_ptr: &opaque, metadata: &uint8, buckets: &BucketType.TerraType)
-		htable.capacity = capacity
-		htable.size = size
-		htable.opaque_ptr = opaque_ptr
-		htable.metadata = metadata
-		htable.buckets = buckets
-	end
-
-	terra DenseHashTable:init()
-		var initial_capacity = GroupLength
-		var calloc_result = table_calloc(initial_capacity)
-
-		-- We are just assuming that the memory allocation succeeded. If it didn't then something much bigger is happening. 
-		var opaque_ptr, metadata, buckets = calloc_result.ok
-
-		self:_init {
-			capacity = initial_capacity,
-			size = 0,
-			opaque_ptr = opaque_ptr,
-			metadata = metadata,
-			buckets = buckets,
-			entries = nil
-		}
-	end
-
-	terra DenseHashTable:destruct()
-		if self.opaque_ptr ~= nil then
-			[Alloc]:free_raw(self.opaque_ptr)
-		end
-
-		CStr.memset(self, 0, sizeof(DenseHashTable))
-	end
-
-	terra DenseHashTable:lookup_handle(key: BucketType.KeyType): BucketHandle 
-		var hash_result = compute_hash(key, self.capacity)
-		var virtual_limit = self.capacity + hash_result.initial_bucket_index
-
-		for virtual_index = hash_result.initial_bucket_index, virtual_limit do
-			var index = virtual_index and (self.capacity - 1)
-			var metadata = self.metadata[index]
-
-			if metadata == MetadataEmpty or (metadata == hash_result.h2 and IsKeyEq(key, self.buckets[index])) then
-				return BucketHandle.ok(BucketIndex {index, hash_result})
-			end
-		end
-
-		return BucketHandle.err(1)
-	end
-
-	local StoreHandleBody = macro(function(self, handle, key, value) 
-		return quote
-			if [handle]:is_err() then
-				return [handle].err
-			end
-
-			var bucket_index = [handle].ok 
-			var index = bucket_index.index
-			var hash_result = bucket_index.hash_result
-			var previous_metadata = self.metadata[index]	
-
-			[self].metadata[index] = hash_result.h2
-			[self].buckets[index] = CreateBucket(key, value)
-
-			if previous_metadata == MetadataEmpty then
-				[self].size = [self].size + 1
-			end
-
-			return 0
-		end
-	end)
-
-	BucketType:Match(
-		function(StructCase)
-			terra DenseHashTable:store_handle(handle: BucketHandle, key: StructCase.KeyType, value: StructCase.ValueType): int
-				StoreHandleBody(self, handle, key, value)
-			end
-		end,
-		function(KeyCase)
-			terra DenseHashTable:store_handle(handle: BucketHandle, key: KeyCase.KeyType): int
-				StoreHandleBody(self, handle, key, nil)
-			end
-		end
-	)
-
-
-	terra DenseHashTable:retrieve_handle(handle: BucketHandle): RetrieveResult
-		if handle:is_err() then
-			return RetrieveResult.err(handle.err)
-		end
-
-		var metadata = self.metadata[handle.ok.index]
-		if metadata ~= MetadataEmpty then
-			var bucket = self.buckets[handle.ok.index]
-			return RetrieveResult.ok([BucketType:ChooseFn(
-										function(s) return `{[s].key, [s].value} end,
-										function(k) return k end,
-										`bucket)])
-		else
-			return RetrieveResult.err(0)
-		end
-	end
-
-	terra DenseHashTable:resize(): int
-		var old_size = self.size
-		var old_capacity = self.capacity
-		var old_opaque_ptr = self.opaque_ptr
-		var old_metadata = self.metadata
-		var old_buckets = self.buckets
-
-		var new_capacity = self.capacity * 2
-		var calloc_result = table_calloc(new_capacity)
-
-		if calloc_result:is_err() then
-			return calloc_result.err
-		end
-
-		var new_opaque_ptr, new_metadata, new_buckets = calloc_result.ok
-
-		reassign_internals(self, new_capacity, 0, new_opaque_ptr, new_metadata, new_buckets)
-
-		for i = 0, old_capacity do
-			if old_metadata[i] ~= MetadataEmpty then
-				var old_bucket: BucketType.TerraType = old_buckets[i]
-				var handle = self:lookup_handle(GetBucketKey(old_bucket))
-				var result = [BucketType:ChooseFn(
-								function(s) return `self:store_handle(handle, [s].key, [s].value) end,
-								function(k) return `self:store_handle(handle, [k]) end,
-								`old_bucket)]
-
-				if result ~= 0 then
-					-- An error occured when rehashing. Reset the state of the hashtable and return an error.
-					reassign_internals(self, old_capacity, old_size, old_opaque_ptr, old_metadata, old_buckets)
-					[Alloc]:free(new_opaque_ptr)
-					return result
-				end
-			end
-		end
-
-		-- Free old data
-		[Alloc]:free(old_opaque_ptr)
-
-		return 0
-	end
-
-	local function GenerateDebugHeader()
-		local bucket_type_str = BucketType:Match(
-			function(StructCase) return "struct { key: " .. tostring(StructCase.KeyType) .. ", value: " .. tostring(StructCase.ValueType) .. " }" end,
-			function(KeyCase) return tostring(KeyCase.KeyType) end)
-		return "DenseHashTable - BucketType: " .. bucket_type_str .. ", Size: %u, Capacity: %u, OpaquePtr: %p\n"
-	end
-
-	-- Prints a debug view of the metadata array to stdout
-	terra DenseHashTable:_debug_metadata_repr()
-		Cstdio.printf([GenerateDebugHeader()], self.size, self.capacity, self.opaque_ptr)
-		for i = 0, self.capacity do
-			Cstdio.printf("[%u]\t%p - 0x%02X\n", i, self.metadata + i, self.metadata[i])
-		end
-	end
-
-	-- Prints a debug view of the table to stdout.
-	terra DenseHashTable:debug_full_repr()
-		Cstdio.printf([GenerateDebugHeader()], self.size, self.capacity, self.opaque_ptr)
-		for i = 0, self.capacity do
-			Cstdio.printf("[%u]\tMetadata: %p = 0x%02X\tBucket: %p = ", i, self.metadata + i, self.metadata[i], self.buckets + i)
-
-			if self.metadata[i] == 128 then
-				Cstdio.printf("Empty\n", self.buckets + i)
-			elseif self.buckets + i == nil then
-				Cstdio.printf("NULLPTR\n")
-			else
-				escape
-					local function MapFormatString(T)
-						if T == rawstring then
-							return "%s"
-						elseif T:isintegral() then
-							return "%d"
-						elseif T:isfloat() then
-							return "%f"
-						elseif T:ispointer() then
-							return "%p"
-						else
-							return tostring(T)
-						end
-					end
-
-					BucketType:Match(
-						function(StructCase)
-							local format_string = MapFormatString(StructCase.KeyType) .. ": " .. MapFormatString(StructCase.ValueType) .. "\n"
-							emit(`Cstdio.printf(format_string, self.buckets[i].key, self.buckets[i].value))
-						end,
-						function(KeyCase)
-							emit(`Cstdio.printf([MapFormatString(KeyCase.KeyType) .. "\n"], self.buckets[i]))
-						end
-					)
-				end
-			end
-		end
-	end
-
-	return DenseHashTable
-end
 
 -- Implementation of djb2. Treats all data as a stream of bytes.
 terra M.hash_djb2(data: &int8, size: uint): uint
@@ -348,7 +26,7 @@ function M.CreateDefaultHashFunction(KeyType)
 	-- TODO: Add more cases here
 	else
 		local terra naive_hash(obj: KeyType)
-			return M.hash_djb2([&int8] (&obj), sizeof(KeyType))
+			return M.hash_djb2(obj, sizeof(obj))
 		end
 		return naive_hash
 	end
@@ -360,6 +38,217 @@ function M.CreateDefaultEqualityFunction(KeyType)
 		return k1 == k2
 	end
 	return naive_equal_function
+end
+
+function M.CreateHashTableSubModule(KeyType, HashFn, EqFn, Alloc)
+	HashFn = HashFn or M.CreateDefaultHashFunction(KeyType)
+	EqFn = EqFn or M.CreateDefaultEqualityFunction(KeyType)
+	Alloc = Alloc or A.default_allocator
+
+	local SM = {}
+
+	SM.MetadataHashBitmap = constant(uint8, 127) -- 0b01111111
+	SM.MetadataEmpty = constant(uint8, 128) -- 0b10000000
+	SM.GroupLength = constant(uint, 16)
+
+	-- Produces a collection of methods used for the HashTable implementation.
+	-- This is considered to be an implementation detail and subject to API changes. The only reason this is exposed is for automated testing purposes.
+	SM._Plumbing = {}
+
+	-- Allocates and initalizes memory for the hashtable. The metadata array is initalized to `MetadataEmpty`. Buckets are not initialized to any value.
+	-- Returns a quadruple: The first value is success, the second value is an opaque pointer which should be passed to `free`, the third value is the metadata array, and the forth value is the bucket array.
+	-- Note that if success is false, then all other values are null.
+	terra SM._Plumbing.table_calloc(capacity: uint): tuple(bool, &opaque, &uint8, &KeyType)
+		var opaque_ptr = Alloc:alloc_raw(capacity * (sizeof(KeyType) + 1))
+		
+		if opaque_ptr == nil then
+			return {false, nil, nil, nil}
+		end
+
+		var metadata_array = [&uint8](opaque_ptr)
+		var buckets_array = [&KeyType](metadata_array + capacity)
+
+		CStr.memset(metadata_array, SM.MetadataEmpty, capacity)
+
+		return {true, opaque_ptr, metadata_array, buckets_array}
+	end
+
+	struct SM._Plumbing.HashResult {
+		initial_bucket_index: uint
+		h1: uint
+		h2: uint8
+	}
+
+	terra SM._Plumbing.compute_hashes(key: KeyType, capacity: uint): SM._Plumbing.HashResult
+		var hash = [ HashFn ](key)
+
+		return SM._Plumbing.HashResult {
+			initial_bucket_index = (hash >> 7) % capacity,
+			h1 = hash >> 7,
+			h2 = hash and SM.MetadataHashBitmap
+		}
+	end
+
+	-- Probes the table for the bucket that would contain the key.
+	-- Expects that capacity is a power of 2.
+	-- Returns an index which is only valid for the current state of the table. The index may point to a bucket which contains an existing key, 
+	-- or to an empty bucket where the key should be inserted if the key does not exist.
+	-- The return value is negative if no bucket can be found.
+	terra SM._Plumbing.probe(key: KeyType,
+							 hash_result: SM._Plumbing.HashResult,
+							 metadata_array: &uint8,
+							 buckets: &KeyType,
+							 capacity: uint): int
+		for virtual_index = hash_result.initial_bucket_index, capacity + hash_result.initial_bucket_index do
+			var index = virtual_index and (capacity -1)
+			var metadata = metadata_array[index]
+
+			if metadata == SM.MetadataEmpty or (metadata == hash_result.h2 and [EqFn](key, buckets[index])) then
+				return index
+			end
+		end
+
+		return -1
+	end
+
+	SM._Plumbing.probe_table = macro(function(hash_table, key, hash_result)
+		return `SM._Plumbing.probe(key, hash_result, hash_table.metadata, hash_table.buckets, hash_table.capacity)
+	end)
+
+	-- Inserts a key into buckets and sets appropriate metadata.
+	-- The reason this is a plumbing function instead of public api is because rehash needs to perform insertions.
+	terra SM._Plumbing.insert(key: KeyType, metadata_array: &uint8, buckets: &KeyType, capacity: uint)
+		var hash_result = SM._Plumbing.compute_hashes(key, capacity)
+		var index = SM._Plumbing.probe(key, hash_result, metadata_array, buckets, capacity)
+
+		metadata_array[index] = hash_result.h2
+		buckets[index] = key
+	end
+
+	terra SM._Plumbing.rehash_table(old_metadata: &uint8,
+									old_buckets: &KeyType,
+									old_capacity: uint,
+									new_metadata: &uint8,
+									new_buckets: &KeyType,
+									new_capacity: uint)
+		for i = 0, old_capacity do
+			if old_metadata[i] ~= SM.MetadataEmpty then
+				var key = old_buckets[i]
+				SM._Plumbing.insert(key, new_metadata, new_buckets, new_capacity)
+			end
+		end
+	end
+
+	-- Resizes the hashtable.
+	-- Returns true on success, false otherwise.
+	terra SM._Plumbing.resize_hashtable(hashtable: &SM.HashTable): bool
+		var new_capacity = hashtable.capacity * 2
+		var alloc_success, opaque_ptr, new_metadata, new_buckets = SM._Plumbing.table_calloc(new_capacity)
+
+		if alloc_success == false then
+			return false
+		end
+
+		SM._Plumbing.rehash_table(hashtable.metadata, hashtable.buckets, hashtable.capacity, new_metadata, new_buckets, new_capacity)
+
+		[Alloc]:free_raw(hashtable.opaque_ptr)
+		hashtable.opaque_ptr = opaque_ptr
+		hashtable.metadata = new_metadata
+		hashtable.buckets = new_buckets
+		hashtable.capacity = new_capacity
+
+		return true
+	end
+	
+	struct SM.HashTable(O.Object) {
+		-- The total number of buckets in the table.
+		capacity: uint
+		-- The number of items stored in the table
+		size: uint
+		-- Pointer to free on destruction
+		opaque_ptr: &opaque
+		-- Array of bytes holding the metadata of the table.
+		metadata: &uint8
+		-- The backing array of the hashtable.
+		buckets: &KeyType
+	}
+
+	terra SM.HashTable:init()
+		var initial_capacity = SM.GroupLength
+		var alloc_success, opaque_ptr, metadata, buckets = SM._Plumbing.table_calloc(initial_capacity)
+		
+		self:_init {
+			capacity = initial_capacity,
+			size = 0,
+			opaque_ptr = opaque_ptr,
+			metadata = metadata,
+			buckets = buckets
+		}
+	end
+
+	terra SM.HashTable:destruct()
+		[Alloc]:free_raw(self.opaque_ptr)
+		self.opaque_ptr = nil
+		self.metadata = nil
+		self.buckets = nil
+		self.size = 0
+		self.capacity = 0
+	end
+
+	-- Inserts the key into the table. If the table is full, a resize is triggered.
+	terra SM.HashTable:insert(key: KeyType)
+		if self.size == self.capacity then
+			SM._Plumbing.resize_hashtable(self)
+		end
+
+		SM._Plumbing.insert(key, self.metadata, self.buckets, self.capacity)
+		self.size = self.size + 1
+	end
+
+	-- Tests if the table has a key of the specified value. Returns true if a value exists, false otherwise.
+	terra SM.HashTable:has(key: KeyType): bool
+		var hash_result = SM._Plumbing.compute_hashes(key, self.capacity)
+		var probe_index = SM._Plumbing.probe_table(self, key, hash_result)
+
+		if probe_index == -1 or self.metadata[probe_index] == SM.MetadataEmpty then
+			return false
+		end
+
+		return true
+	end
+
+	-- Prints a debug view of the metadata array to stdout
+	terra SM.HashTable:debug_metadata_repr()
+		Cstdio.printf("HashTable Size: %u, Capacity: %u, OpaquePtr: %p\n", self.size, self.capacity, self.opaque_ptr)
+		for i = 0, self.capacity do
+			Cstdio.printf("[%u]\t%p - 0x%02X\n", i, self.metadata + i, self.metadata[i])
+		end
+	end
+
+	-- Prints a debug view of the table to stdout.
+	terra SM.HashTable:debug_full_repr()
+		Cstdio.printf("HashTable Size: %u, Capacity: %u, OpaquePtr: %p\n", self.size, self.capacity, self.opaque_ptr)
+		for i = 0, self.capacity do
+			Cstdio.printf("[%u]\tMetadata: %p = 0x%02X\tBucket: %p = ", i, self.metadata + i, self.metadata[i], self.buckets + i)
+
+			if self.metadata[i] == 128 then
+				Cstdio.printf("Empty\n", self.buckets + i)
+			elseif self.buckets + i == nil then
+				Cstdio.printf("NULLPTR\n")
+			else
+				-- TODO: this won't work all the time, refactor to handle all types later
+				Cstdio.printf("%s\n", self.buckets[i])
+			end
+		end
+	end
+
+	return SM
+end
+
+-- Convienience function that returns a HashTable struct type.
+function M.HashTable(KeyType, HashFn, EqFn, Alloc)
+	local SM = M.CreateHashTableSubModule(KeyType, HashFn, EqFn, Alloc)
+	return SM.HashTable
 end
 
 return M

--- a/hashtable.t
+++ b/hashtable.t
@@ -212,8 +212,10 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 	end
 
 	terra HashTable:destruct()
-		[Alloc]:free_raw(self.opaque_ptr)
-		CStr.memset(self, 0, sizeof(HashTable)) 
+		if self.opaque_ptr ~= nil then
+			[Alloc]:free_raw(self.opaque_ptr)
+			CStr.memset(self, 0, sizeof(HashTable))
+		end
 	end
 
 	-- Resizes the hashtable to be at least the size of the requested_capacity.
@@ -241,6 +243,9 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 
 				if insert_result:is_err() then
 					[Alloc]:free_raw(new_opaque)
+					new_opaque = nil
+					new_metadata = nil
+					new_buckets = nil
 					return insert_result.err
 				end
 			end
@@ -298,9 +303,9 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 		end
 	end
 
+	-- Debug print functions
 	local DebugHeaderString = "HashTable" .. BucketType:ParamsToTypeString() .. " Size: %u; Capacity: %u; OpaquePtr: %p\n"
 
-	-- Prints a debug view of the metadata array to stdout
 	terra HashTable:debug_metadata_repr()
 		Cstdio.printf(DebugHeaderString, self.size, self.capacity, self.opaque_ptr)
 		for i = 0, self.capacity do

--- a/hashtable.t
+++ b/hashtable.t
@@ -10,6 +10,13 @@ local M = {}
 
 M.Implementation = {}
 
+-- Note for myself in the future, because I've done this at least five times now:
+-- No, you cannot simplify everything by condensing `KeyType` and `ValueType` into a single `BucketType`.
+-- IT. DOES. NOT. WORK.
+-- It works for every single function *except* `lookup_handle`. `lookup_handle` determines not just where 
+-- a potentially new key/value is supposed to go, but also what the value associated with the given key is.
+-- A `get` method that required you to specify the key AND the value would be pretty useless wouldn't it?
+
 local function M.Implementation.DenseHashTable(KeyType, ValueType, HashFn, EqFn, Alloc)
 	local MetadataHashBitmap = constant(uint8, 127) -- 0b01111111
 	local MetadataEmpty = constant(uint8, 128) -- 0b10000000
@@ -120,7 +127,7 @@ local function M.Implementation.DenseHashTable(KeyType, ValueType, HashFn, EqFn,
 		var calloc_result = table_calloc(initial_capacity)
 
 		-- We are just assuming that the memory allocation succeeded. If it didn't then something much bigger is happening. 
-		var opaque_ptr, metadata, buckets = calloc_result.result
+		var opaque_ptr, metadata, buckets = calloc_result.ok
 
 		self:_init {
 			capacity = initial_capacity,

--- a/hashtable.t
+++ b/hashtable.t
@@ -155,6 +155,9 @@ function M.CreateHashTableSubModule(KeyType, HashFn, EqFn, Alloc)
 		hashtable.opaque_ptr = opaque_ptr
 		hashtable.metadata = new_metadata
 		hashtable.buckets = new_buckets
+		hashtable.capacity = new_capacity
+
+		return true
 	end
 	
 	struct SM.HashTable(O.Object) {

--- a/hashtable.t
+++ b/hashtable.t
@@ -120,6 +120,18 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 		return "HashTable[" .. tostring(KeyType) .. (ValueType ~= nil and ", " .. tostring(ValueType) or "") .. "]"
 	end
 
+	function HashTable.metamethods.__for(self, body)
+		return quote
+			var this = self
+			for i = 0, this.capacity do
+				if this.metadata[i] ~= MetadataEmpty then
+					var bucket = this.buckets[i]
+					[body(bucket)]
+				end
+			end
+		end
+	end
+
 	-- Result types
 	local CallocResult = R.MakeResult(tuple(&opaque, &uint8, &BucketType), M.Errors.ErrorType)
 	local ProbeResult = R.MakeResult(uint, M.Errors.ErrorType)

--- a/hashtable.t
+++ b/hashtable.t
@@ -271,7 +271,7 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 				return insert_result.err
 			end
 
-			if insert_result.ok.old_metadata ~= MetadataEmpty then
+			if insert_result.ok.old_metadata == MetadataEmpty then
 				self.size = self.size + 1
 			end 
 

--- a/hashtable.t
+++ b/hashtable.t
@@ -178,7 +178,7 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 	end
 
 	terra HashTable:destruct()
-		[Alloc]:free_raw()
+		[Alloc]:free_raw(self.opaque_ptr)
 		CStr.memset(self, 0, sizeof(HashTable)) 
 	end
 

--- a/hashtable.t
+++ b/hashtable.t
@@ -343,6 +343,7 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 	end
 
 	local EntryResult = R.MakeResult(Entry, M.Errors.ErrorType)
+	local ValueResult = R.MakeResult(ValueType, M.Errors.ErrorType)
 
 	terra HashTable:entry(key: KeyType): EntryResult
 		var hash_info, probe_index = hash_probe(key, self.metadata, self.buckets, self.capacity):unwrap()
@@ -353,6 +354,11 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 		return self.hash_table.metadata[self.index] == MetadataEmpty
 	end
 
+	terra Entry:key(): KeyType
+		return self.hash_info.key
+	end
+
+
 	if BucketType.IsKeyValue then
 		terra Entry:or_insert(value: ValueType): ValueType
 			if (self:is_empty()) then
@@ -362,6 +368,11 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 			end
 
 			return self.buckets[self.index].value
+		end
+
+		-- TODO: This should be an Option when those exist. Result will work for now.
+		terra Entry:value(): ValueResult
+			return self:is_empty() and ValueResult.err(M.Errors.NotFound) or ValueResult.ok(self.hash_table.buckets[self.index]
 		end
 	else
 		terra Entry:or_insert(): KeyType

--- a/hashtable.t
+++ b/hashtable.t
@@ -135,7 +135,7 @@ local function HashTable(KeyType, EqFn, HashFn, Alloc)
 		end
 
 		-- Free old memory
-		[ Alloc ]:free_raw(new_metadata)
+		[ Alloc ]:free_raw(hashtable.metadata)
 
 		hashtable.capacity = new_capacity
 		hashtable.metadata = new_metadata

--- a/hashtable.t
+++ b/hashtable.t
@@ -110,7 +110,7 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 		end
 
 		var metadata_array = [&uint8](opaque_ptr)
-		var buckets_array = [&KeyType](metadata_array + capacity)
+		var buckets_array = [&BucketType](metadata_array + capacity)
 
 		CStr.memset(metadata_array, MetadataEmpty, capacity)
 

--- a/hashtable.t
+++ b/hashtable.t
@@ -146,11 +146,11 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 
 	-- Inserts a bucket into the provided hashtable.
 	-- Returns a result containing an InsertData or an error code 
-	local terra insert_bucket(bucket: BucketType, metadata_array: &uint8, buckets_array: BucketType, capacity: uint): InsertResult 
+	local terra insert_bucket(bucket: BucketType, metadata_array: &uint8, buckets_array: &BucketType, capacity: uint): InsertResult 
 		var hash_info = compute_hash_information(bucket.key, capacity)
 		var probe_result = linear_probe(hash_info, metadata_array, buckets_array, capacity)
 
-		if probe_result.is_err() then
+		if probe_result:is_err() then
 			return InsertResult.err(probe_result.err)
 		end
 
@@ -175,7 +175,7 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 		var initial_capacity = SM.GroupLength
 		var calloc_result = table_calloc(initial_capacity)
 		
-		if calloc_result.is_ok() then
+		if calloc_result:is_ok() then
 			var opaque_ptr, metadata, buckets = calloc_result.ok
 			
 			self:_init {
@@ -203,7 +203,7 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 		var new_capacity = find_next_power_of_two(self.capacity, requested_capacity) 
 		var calloc_result = table_calloc(new_capacity)
 
-		if calloc_result.is_err() then
+		if calloc_result:is_err() then
 			return calloc_result.err
 		end
 
@@ -215,7 +215,7 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 				var bucket = self.buckets[i]
 				var insert_result = insert_bucket(bucket, new_metadata, new_buckets, new_capacity)
 
-				if insert_result.is_err() then
+				if insert_result:is_err() then
 					[Alloc]:free_raw(new_opaque)
 					return inset_result.err
 				end
@@ -235,7 +235,7 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 		var hash_information = compute_hash_information(key, self.capacity)
 		var probe_result = linear_probe(self, key, hash_information)
 
-		if probe_result.is_ok() and self.metadata[probe_result.ok] ~= MetadataEmpty then
+		if probe_result:is_ok() and self.metadata[probe_result.ok] ~= MetadataEmpty then
 			return true
 		else
 			return false
@@ -250,7 +250,7 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 			
 			var insert_result = insert_bucket([bucket], [self].metadata, [self].buckets, [self].capacity)
 
-			if insert_result.is_err() then
+			if insert_result:is_err() then
 				return insert_result.err
 			end
 

--- a/hashtable.t
+++ b/hashtable.t
@@ -46,7 +46,7 @@ function HashTable(KeyType, HashFn, Alloc)
 		-- The number of items stored in the table
 		size: uint
 		-- Array of bytes holding the metadata of the table.
-		metadata: &int8
+		metadata: &uint8
 		-- The backing array of the hashtable.
 		buckets: &KeyType
 	}
@@ -57,10 +57,19 @@ function HashTable(KeyType, HashFn, Alloc)
 		h2: uint8
 	}
 
-	-- Allocates memory large enough to fit the provided number of groups and associated metadata. Returns a pointer to this block of memory.
-	local terra malloc_by_groups(groups: uint): &opaque
+	-- Allocates memory large enough to fit the provided number of groups and associated metadata.
+	-- Returns a pointer to the metadata array and a pointer to the bucket array.
+	local terra malloc_by_groups(groups: uint): tuple(&uint8, &KeyType)
 		var buckets = groups * GroupLength
-		return [ Alloc ]:alloc_raw(buckets + (sizeof([KeyType]) * buckets))
+		var big_ol_chunk_of_memory = [ Alloc ]:alloc_raw(buckets + (sizeof([KeyType]) * buckets))
+		return { [&uint8] (big_ol_chunk_of_memory), [&KeyType] ([&uint8] big_ol_chunk_of_memory + GroupLength) }
+	end
+
+	-- Initalizes the metadata array with MetadataEmpty
+	local terra initalize_metadata(metadata_array: &uint8, length: uint)
+		for i = 0, self.length do
+			metadata_array[i] = MetadataEmpty
+		end
 	end
 
 	local terra compute_hashes(capacity: uint, key: KeyType): HashResult
@@ -73,28 +82,82 @@ function HashTable(KeyType, HashFn, Alloc)
 		}
 	end
 
+	--[[ 
+		Probes the table for the bucket that would contain the key. Capacity should be a power of 2.
+		
+		Returns an index which is only valid for the current state of the table. 
+		This index may point to a bucket which contains the key, or an empty bucket where the key should be inserted if the key does not exist.
+		The return value is negative if an error occured.
+	]]--
+	local terra probe_clever(hash_result: HashResult, metadata_array: &uint8, capacity: uint): int
+		for j = hash_result.bucket_index, capacity + hash_result.bucket_index do
+			i = j and (capacity - 1)
+			var m = metadata_array[i]
+
+			if m == MetadataEmpty or m == hash_result.h2 then
+				return i
+			end
+		end
+
+		return -1
+	end
+
+	-- Resizes the hashtable by doubling the number of groups.
+	local terra resize_hashtable(hashtable: Hashtable)
+		var old_group_count = hashtable.capacity / GroupLength
+		var new_group_count = old_group_count * 2
+		var new_capacity = new_group_count * GroupLength
+
+		-- Not using realloc because we need rehash everything.
+		-- That's going to be really hard within the same memory segment
+		var new_metadata, new_buckets = malloc_by_groups(new_group_count)
+
+		initalize_metadata(new_memory_chunk, new_capacity)
+
+		-- Iterate through the old hashtable and rehash
+		for i = 0, hashtable.capacity do
+			if hashtable.metadata[i] != MetadataEmpty then
+				var key = hashtable.buckets[i]
+				var hash_result = compute_hashes(new_capacity, key)
+				var probe_index = probe_clever(hash_result, new_metadata, new_capacity)
+
+				new_metadata[probe_index] = hash_result.h2
+				new_buckets[probe_index] = key
+			end
+		end
+
+		-- Free old memory
+		[ Alloc ]:free_raw(new_metadata)
+
+		hashtable.capacity = new_capacity
+		hashtable.metadata = new_metadata
+		hashtable.buckets = new_buckets
+	end
+
 	terra Hashtable:init()
-		var big_ol_chunk_of_memory = malloc_by_groups(1)
+		var metadata, buckets = malloc_by_groups(1)
 		
 		self:_init {
 			capacity = GroupLength,
 			size = 0,
-			metadata = [&int8] (big_ol_chunk_of_memory),
-			buckets =  [&KeyType] ( [&int8] (big_ol_chunk_of_memory) + GroupLength)
+			metadata = metadata,
+			buckets = buckets
 		}
 
-		-- Initialize the metadata array
-		for i = 0, self.capacity do
-			self.metadata[i] = MetadataEmpty
-		end
+		initalize_metadata(self.metadata, self.capacity)
 	end
 
 	terra Hashtable:insert(key: KeyType)
+		if self.size == self.capacity then
+			resize_hashtable(self)
+		end
+
 		var hash_result = compute_hashes(self.capacity, key)
+		var probe_index = probe_clever(hash_result, self.metadata, self.capacity)
 
 		self.size = self.size + 1
-		self.metadata[hash_result.bucket_index] = hash_result.h2
-		self.buckets[hash_result.bucket_index] = key
+		self.metadata[probe_index] = hash_result.h2
+		self.buckets[probe_index] = key
 	end
 
 	return Hashtable

--- a/hashtable.t
+++ b/hashtable.t
@@ -343,7 +343,6 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 	end
 
 	local EntryResult = R.MakeResult(Entry, M.Errors.ErrorType)
-	local ValueResult = R.MakeResult(ValueType, M.Errors.ErrorType)
 
 	terra HashTable:entry(key: KeyType): EntryResult
 		var hash_info, probe_index = hash_probe(key, self.metadata, self.buckets, self.capacity):unwrap()
@@ -360,6 +359,8 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 
 
 	if BucketType.IsKeyValue then
+		local ValueResult = R.MakeResult(ValueType, M.Errors.ErrorType)
+
 		terra Entry:or_insert(value: ValueType): ValueType
 			if (self:is_empty()) then
 				self.hash_table.metadata[self.index] = self.hash_info.h2
@@ -372,7 +373,7 @@ function M.HashTable(KeyType, ValueType, HashFn, EqFn, Options, Alloc)
 
 		-- TODO: This should be an Option when those exist. Result will work for now.
 		terra Entry:value(): ValueResult
-			return self:is_empty() and ValueResult.err(M.Errors.NotFound) or ValueResult.ok(self.hash_table.buckets[self.index]
+			return self:is_empty() and ValueResult.err(M.Errors.NotFound) or ValueResult.ok(self.hash_table.buckets[self.index])
 		end
 	else
 		terra Entry:or_insert(): KeyType

--- a/result.t
+++ b/result.t
@@ -15,13 +15,13 @@ local function MakeBaseErrorString(from, to)
 end
 
 local function AssertCastingToResultType(from, to)
-	if to.is_result != true then
+	if to.is_result ~= true then
 		error(MakeBaseErrorString(from, to) .. " Cannot convert from result to non-result type.")
 	end
 end
 
 local function AssertCastingTypeParamEqual(from, to, param_name, expected_value)
-	if to[param_name] != expected_value then
+	if to[param_name] ~= expected_value then
 		error(MakeBaseErrorString(from, to) .. " Type parameter " .. param_name .. "mismatched.")
 	end
 end
@@ -33,13 +33,13 @@ M.MakeOkayResult = terralib.memoize(function(OkayType)
 	}
 	BlessResult(OkayResult, OkayType, nil)
 
-	function OkayType.metafunctions.__cast(from, to, expr)
+	function OkayResult.metamethods.__cast(from, to, expr)
 		AssertCastingToResultType(from, to)
 		AssertCastingTypeParamEqual(from, to, "OkayType", OkayType)
 		return `[to].ok([expr].ok)
 	end
 
-	return OkayType
+	return OkayResult
 end)
 
 -- A result that can only be an error
@@ -49,9 +49,11 @@ M.MakeErrorResult = terralib.memoize(function(ErrorType)
 	}
 	BlessResult(ErrorResult, nil, ErrorType)
 
-	function ErrorResult.metafunctions.__cast(from, to, expr)
+	function ErrorResult.metamethods.__cast(from, to, expr)
+		print("ErrorResult cast")
 		AssertCastingToResultType(from, to)
 		AssertCastingTypeParamEqual(from, to, "ErrorType", ErrorType)
+		error("The cast was called")
 		return `[to].err([expr].err)
 	end
 

--- a/result.t
+++ b/result.t
@@ -1,0 +1,23 @@
+import "std.enum"
+
+local M = {}
+
+function M.MakeOption(T)
+	local enum Option {
+		none,
+		some: T
+	}
+	
+	return Option
+end
+
+function M.MakeResult(ResultType, FailureType)
+	local enum Result {
+		result: ResultType,
+		failure: FailureType
+	}
+
+	return Result
+end
+
+return M

--- a/result.t
+++ b/result.t
@@ -1,23 +1,16 @@
 import "std.enum"
 
+local CT = require 'std.constraint'
+
 local M = {}
 
-function M.MakeOption(T)
-	local enum Option {
-		none,
-		some: T
-	}
-	
-	return Option
-end
-
-function M.MakeResult(ResultType, FailureType)
+M.MakeResult = terralib.memoize(function(OkayType, ErrorType)
 	local enum Result {
-		result: ResultType,
-		failure: FailureType
+		ok: OkayType,
+		err: ErrorType
 	}
 
 	return Result
-end
+end)
 
 return M

--- a/result.t
+++ b/result.t
@@ -4,11 +4,79 @@ local CT = require 'std.constraint'
 
 local M = {}
 
+-- Adds metaprogramming values to the the provded ResultType, to distinguish it as a Result.
+local function BlessResult(ResultType, OkayType, ErrorType)
+	ResultType.is_result = true
+	ResultType.type_parameters = { OkayType = OkayType, ErrorType = ErrorType }
+end
+
+local function MakeBaseErrorString(from, to)
+	return "Invalid cast from " .. tostring(from) .. " to " .. tostring(to) .. ":"
+end
+
+local function AssertCastingToResultType(from, to)
+	if to.is_result != true then
+		error(MakeBaseErrorString(from, to) .. " Cannot convert from result to non-result type.")
+	end
+end
+
+local function AssertCastingTypeParamEqual(from, to, param_name, expected_value)
+	if to[param_name] != expected_value then
+		error(MakeBaseErrorString(from, to) .. " Type parameter " .. param_name .. "mismatched.")
+	end
+end
+
+-- A result that can only be an okay
+M.MakeOkayResult = terralib.memoize(function(OkayType)
+	local enum OkayResult {
+		ok: OkayType
+	}
+	BlessResult(OkayResult, OkayType, nil)
+
+	function OkayType.metafunctions.__cast(from, to, expr)
+		AssertCastingToResultType(from, to)
+		AssertCastingTypeParamEqual(from, to, "OkayType", OkayType)
+		return `[to].ok([expr].ok)
+	end
+
+	return OkayType
+end)
+
+-- A result that can only be an error
+M.MakeErrorResult = terralib.memoize(function(ErrorType)
+	local enum ErrorResult {
+		err: ErrorType
+	}
+	BlessResult(ErrorResult, nil, ErrorType)
+
+	function ErrorResult.metafunctions.__cast(from, to, expr)
+		AssertCastingToResultType(from, to)
+		AssertCastingTypeParamEqual(from, to, "ErrorType", ErrorType)
+		return `[to].err([expr].err)
+	end
+
+	return ErrorResult
+end)
+
 M.MakeResult = terralib.memoize(function(OkayType, ErrorType)
 	local enum Result {
 		ok: OkayType,
 		err: ErrorType
 	}
+	BlessResult(Result, OkayType, ErrorType)
+
+	Result.apply = macro(function(self, fn)
+		
+	end)
+
+	Result.unwrap = macro(function(self) 
+		return quote 
+			var s = self
+			if s:is_ok() then
+				return s 
+			end 
+		in s.ok end 
+	end)
 
 	return Result
 end)

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  nativeBuildInputs = 
+    let
+      fundament-terra = import (pkgs.fetchFromGitHub {
+        owner = "Fundament-Software";
+        repo = "terra";
+        rev = "89b5c7cb71fa4aaaeb2b4ff5d3fe0389fec15268";
+        sha256 = "05drwz75ah774g6b70d01v2glg8aj6p0ahz4cb88inr6jijzd57g";
+      }) { inherit pkgs; };
+    in
+      [ fundament-terra ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -6,8 +6,8 @@ pkgs.mkShell {
       fundament-terra = import (pkgs.fetchFromGitHub {
         owner = "Fundament-Software";
         repo = "terra";
-        rev = "89b5c7cb71fa4aaaeb2b4ff5d3fe0389fec15268";
-        sha256 = "05drwz75ah774g6b70d01v2glg8aj6p0ahz4cb88inr6jijzd57g";
+        rev = "fb410b202e26c58003dcad4138d42f1189d5954c";
+        sha256 = "1x0f2k5wm1vpazg7v57r7bp5hyfsp5075az4j00qn06y5wyq7g8a";
       }) { inherit pkgs; };
     in
       [ fundament-terra ];

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -9,9 +9,14 @@ end)
 
 describe("Hash table", function()
 
-	it("should have a default constructor", terra()
+	it("init should initalize metadata to MetadataEmpty", terra()
 		var hash_table: HT.HashTable(rawstring)
 		O.new(hash_table)
+
+		-- Assert that metadata is initalized
+		for i = 0, hash_table.capacity do
+			assert.equal(hash_table.metadata[i], 128)
+		end
 	end)
 
 	-- We should add a copy constructor and a capacity constructor.
@@ -19,16 +24,15 @@ describe("Hash table", function()
 	it("should insert entries", terra()
 		var hash_table: HT.HashTable(rawstring)
 		O.new(hash_table)
-
+		
 		var str1 = "According to all known laws of aviation"
 		var str2 = "there is no way that a be should be able to fly"
 		var str3 = "Its wings are too small to get its fat little body off the ground"
-
 		hash_table:insert(str1)
 		hash_table:insert(str2)
 		hash_table:insert(str3)
 		
-		hash_table:debug_repr()
+		hash_table:debug_full_repr()	
 
 		assert.equal(hash_table.size, 3)
 		assert.is_true(hash_table:has(str1))

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -20,12 +20,18 @@ describe("Hash table", function()
 		hash_table:insert("X3")
 		hash_table:insert("OwO")
 
-		var a = hash_table:entry("rawr")
-		var b = hash_table:entry("X3")
-		var c = hash_table:entry("OwO")
+		for i = 0, hash_table.capacity do
+			C.printf("[%d] %x\t", i, hash_table.metadata[i])
+			if hash_table.metadata[i] == 128 then
+				C.printf("Empty\n")
+			else
+				C.printf("%s\n", hash_table.buckets[i])
+			end
+		end
 
-		C.printf("[a] %x - %s\n", @a.metadata, @a.bucket)
-		C.printf("[b] %x - %s\n", @b.metadata, @b.bucket)
-		C.printf("[c] %x - %s\n", @c.metadata, @c.bucket)
+		assert hash_table:has("rawr")
+		assert hash_table:has("X3")
+		assert hash_table:has("OwO")
+
 	end)
 end)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -103,6 +103,26 @@ describe("_Plumbing.probe", function()
 	end)
 end)
 
+describe("_Plumbing.resize_hashtable", function()
+	local StringHashTableModule = HT.CreateHashTableSubModule(rawstring)
+	local Plumbing = StringHashTableModule._Plumbing
+
+	it("should double the size of a hash_table", terra()
+		var test_table: StringHashTableModule.HashTable
+		O.new(test_table)
+
+		test_table:insert("the coldest summer for the rest of your life")
+
+		var old_capacity = test_table.capacity
+		var old_size = test_table.size
+
+		var result = Plumbing.resize_hashtable(&test_table)
+		assert.is_true(result)
+		assert.is_true(old_size == test_table.size)
+		assert.is_true(old_capacity * 2 == test_table.capacity)
+	end)
+end)
+
 describe("HashTable", function()
 
 	it("should initalize metadata to MetadataEmpty", terra()
@@ -132,7 +152,7 @@ describe("HashTable", function()
 		assert.is_true(hash_table:has(str1))
 		assert.is_true(hash_table:has(str2))
 		assert.is_true(hash_table:has(str3))
-
+		assert.is_false(hash_table:has("This string doesn't exist"))
 	end)
 
 

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -15,6 +15,8 @@ describe("HashTable without values", function()
 		assert.equal(0, hash_set:insert(expected._0))
 		assert.equal(0, hash_set:insert(expected._1))
 
+		hash_set:debug_full_repr()
+
 		assert.is_true(hash_set:has(expected._0))
 		assert.is_true(hash_set:has(expected._1))
 		assert.equal(2, hash_set.size)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -149,7 +149,23 @@ describe("HashTable with values", function()
 	end)
 end)
 
-describe("Entry on HashMap", function()
+describe("Entry on HashTable without value", function()
+	local StringHashSet = HT.HashTable(rawstring)
+
+	it("should insert the value if it doesn't exist", terra()
+		var hash_set: StringHashSet
+		hash_set:init()
+
+		var sut = hash_set:entry("sharks").ok
+		assert.is_true(sut:is_empty())
+		assert.equal("sharks", sut:or_insert())
+		assert.is_true(hash_set:has("sharks"))
+
+		hash_set:destruct()
+	end)
+end)
+
+describe("Entry on HashTable with value", function()
 	local StringHashMap = HT.HashTable(rawstring, rawstring)
 
 	it("should insert a value if the value doesn't exist", terra()

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -61,6 +61,24 @@ describe("HashTable without values", function()
 		hash_set:destruct()
 	end)
 
+	it("should not allow a double-remove", terra()
+		var hash_set: StringHashSet
+		hash_set:init()
+
+		hash_set:insert("1")
+		hash_set:insert("2")
+		hash_set:insert("3")
+
+		var first_removal = hash_set:remove("2")
+		assert.is_true(first_removal:is_ok())
+
+		var second_removal = hash_set:remove("2")
+		assert.is_true(second_removal:is_err())
+		assert.equal(HT.Errors.NotFound, second_removal.err)
+
+		hash_set:destruct()
+	end)
+
 	it("should clean the table when rehashing", terra()
 		var hash_set: StringHashSet
 		hash_set:init()

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -22,4 +22,22 @@ describe("Hashtable without values", function()
 end)
 
 describe("Implementation.DenseHashTable HashMap", function()
+	local StringHashMap = HT.HashTable(rawstring, rawstring)
+
+	it("should insert and check the existence of values", terra()
+		var hash_map = O.new(StringHashMap)
+
+		assert.equal(0, hash_map:insert("I'm living proof", "that the worst can be beat"))
+		assert.equal(0, hash_map:insert("if ya pull yourself together", "you can get on your feet"))
+		assert.equal(0, hash_map:insert("living proof that", "the strength you will need"))
+		assert.equal(0, hash_map:insert("has been in you forever", "but to get it, you'll bleed"))
+
+		hash_map:debug_full_repr()
+
+		assert.is_true(hash_map:has("I'm living proof"))
+		assert.is_true(hash_map:has("if ya pull yourself together"))
+		assert.is_true(hash_map:has("living proof that"))
+		assert.is_true(hash_map:has("has been in you forever"))
+		assert.equal(4, hash_map.size)
+	end)
 end)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -1,5 +1,6 @@
 local HT = require 'std.hashtable'
 local O = require 'std.object'
+local A = require 'std.alloc'
 
 local Cio = terralib.includec("stdio.h")
 
@@ -19,7 +20,6 @@ describe("HashTable without values", function()
 		assert.equal(2, hash_set.size)
 	end)
 
-	
 	it("should resize its capacity without changing items", terra()
 		var hash_set: StringHashSet
 		hash_set:init()
@@ -28,7 +28,6 @@ describe("HashTable without values", function()
 		hash_set:insert("and the")
 		hash_set:insert("things that")
 		hash_set:insert("bind us")
-
 
 		assert.equal(0, hash_set:reserve(31))
 		assert.equal(4, hash_set.size)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -48,10 +48,11 @@ describe("HashTable without values", function()
 		assert.equal(3, hash_set.size)
 
 		var rm_result = hash_set:remove("I'm filled")
-		assert.is_true(rm_result:is_ok())
-		assert.equal("I'm filled", rm_result.ok.key)
+		assert.is_true(rm_result:is_ok()) -- Removal should return an ok with the removed object
+		assert.equal("I'm filled", rm_result.ok.key) -- Returned object should be the correct one
 
-		assert.equal(2, hash_set.size)
+		assert.equal(2, hash_set.size) -- Size should decrease by one
+		assert.is_false(hash_set:has("I'm filled")) -- :has() should not report the object as existing
 
 		-- Should return an error
 		assert.equal(HT.Errors.NotFound, hash_set:remove("doesn't exist").err)
@@ -163,6 +164,7 @@ describe("HashTable with values", function()
 		assert.equal(5, hash_map.size)
 		assert.equal("Super Dream World", remove_result.ok.key)
 		assert.equal("Kobaryo", remove_result.ok.value)
+		assert.is_false(hash_map:has("Super Dream World"))
 
 		remove_result = hash_map:remove("404 not found")
 		assert.is_true(remove_result:is_err())

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -3,7 +3,7 @@ local O = require 'std.object'
 
 local Cio = terralib.includec("stdio.h")
 
-describe("Hashtable without values", function()
+describe("HashTable without values", function()
 	local StringHashSet = HT.HashTable(rawstring)
 
 	it("should insert and check the existence of values", terra()
@@ -56,9 +56,31 @@ describe("Hashtable without values", function()
 
 		hash_set:destruct()
 	end)
+
+	it("should create Entry objects for items that exist", terra()
+		var hash_set: StringHashSet
+		hash_set:init()
+		hash_set:insert("sharks")
+
+		var actual = hash_set.entry("sharks")
+		assert.is_false(actual.is_empty())
+		assert.equal("sharks", hash_set.key())
+
+		hash_set:destruct()
+	end)
+
+	it("should create Entry objects for items that don't exist", terra()
+		var hash_set: StringHashSet
+		hash_set:init()
+
+		var actual = hash_set.entry("shark")
+		assert.is_true(actual.is_empty())
+
+		hash_set:destruct()
+	end)
 end)
 
-describe("Implementation.DenseHashTable HashMap", function()
+describe("HashTable with values", function()
 	local StringHashMap = HT.HashTable(rawstring, rawstring)
 
 	it("should insert and check the existence of values", terra()

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -98,6 +98,25 @@ describe("HashTable with values", function()
 		assert.equal(4, hash_map.size)
 	end)
 
+	it("should resize its capacity without changing items", terra()
+		var hash_map: StringHashMap
+		hash_map:init()
+
+		hash_map:insert("1", "Drink Water")
+		hash_map:insert("2", "Eat food")
+		hash_map:insert("3", "Breathe air")
+
+		assert.equal(3, hash_map.size)
+		assert.equal(0, hash_map:reserve(31))
+		assert.is_true(hash_map.capacity >= 31)
+
+		assert.is_true(hash_map:has("1"))
+		assert.is_true(hash_map:has("2"))
+		assert.is_true(hash_map:has("3"))
+
+		hash_map:destruct()
+	end)
+
 	it("should be able to remove items by keys", terra()
 		var hash_map: StringHashMap
 		hash_map:init()

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -5,7 +5,8 @@ local CStr = terralib.includec("string.h")
 local Alloc = require 'std.alloc'
 
 describe("Implementation.DenseHashTable HashSet", function()
-	local IntegerHashSet = HT.Implementation.DenseHashTable(int, nil, HT.CreateDefaultHashFunction(int), HT.CreateDefaultEqualityFunction(int), Alloc.default_allocator)
+	local BucketType = HT.Implementation.BucketType(int)
+	local IntegerHashSet = HT.Implementation.DenseHashTable(BucketType, HT.CreateDefaultHashFunction(int), HT.CreateDefaultEqualityFunction(int), Alloc.default_allocator)
 
 	it("should allow you to insert items", terra()
 		var hash_set: IntegerHashSet
@@ -21,7 +22,8 @@ describe("Implementation.DenseHashTable HashSet", function()
 end)
 
 describe("Implementation.DenseHashTable HashMap", function()
-	local StringHashMap = HT.Implementation.DenseHashTable(rawstring, rawstring, HT.CreateDefaultHashFunction(rawstring), HT.CreateDefaultEqualityFunction(rawstring), Alloc.default_allocator)
+	local BucketType = HT.Implementation.BucketType(rawstring, rawstring)
+	local StringHashMap = HT.Implementation.DenseHashTable(BucketType, HT.CreateDefaultHashFunction(rawstring), HT.CreateDefaultEqualityFunction(rawstring), Alloc.default_allocator)
 	
 	it("should allow you to insert items", terra()
 		var hash_map: StringHashMap

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -61,6 +61,22 @@ describe("HashTable without values", function()
 		hash_set:destruct()
 	end)
 
+	it("should clean the table when rehashing", terra()
+		var hash_set: StringHashSet
+		hash_set:init()
+
+		hash_set:insert("Somewhere in Stockholm")
+		hash_set:insert("Broken Arrows")
+		hash_set:insert("City Lights")
+
+		hash_set:remove("Broken Arrows")
+		hash_set:reserve(31)
+
+		hash_set:debug_full_repr()
+
+		hash_set:destruct()
+	end)
+
 	it("should properly keep track of hash-collided entries", function()
 		local terra bad_hash_function(key: rawstring): uint
 			return 1

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -1,15 +1,111 @@
 local O = require 'std.object'
 local HT = require 'std.hashtable'
 local C = terralib.includec("stdio.h")
+local CStr = terralib.includec("string.h")
 local Alloc = require 'std.alloc'
 
-describe("Hashtable plumbing", function()
-	
+describe("_Plumbing.table_calloc", function()
+	local StringHashTableModule = HT.CreateHashTableSubModule(rawstring)
+	local Plumbing = StringHashTableModule._Plumbing
+
+	it("should allocate enough memory and initalize the metadata portion", terra()
+		var capacity = 8
+		var alloc_success, opaque_ptr, metadata_array, buckets_array = Plumbing.table_calloc(capacity)
+
+		assert.is_true(alloc_success)
+		assert.is_true(opaque_ptr ~= nil)
+
+		for i = 0, capacity do
+			assert.equal(metadata_array[i], 128)
+		end
+
+		Alloc.free(opaque_ptr)
+	end)
 end)
 
-describe("Hash table", function()
+describe("_Plumbing.probe", function()
+	local StringHashTableModule = HT.CreateHashTableSubModule(rawstring)
+	local Plumbing = StringHashTableModule._Plumbing
 
-	it("init should initalize metadata to MetadataEmpty", terra()
+	it("should use initial_bucket_index if the bucket is empty", terra()
+		var test_key = "look at the sky"
+		var test_hash_result = Plumbing.HashResult {
+			initial_bucket_index = 5,
+			h1 = 0,
+			h2 = 69
+		}
+		var test_metadata_array = arrayof(uint8, 128, 128, 128, 128, 128, 128, 128, 128)
+		var test_buckets_array = arrayof(rawstring, "0", "0", "0", "0", "0", "0", "0", "0")
+
+		var actual_index = Plumbing.probe(test_key, test_hash_result, test_metadata_array, test_buckets_array, 8)
+
+		assert.equal(actual_index, test_hash_result.initial_bucket_index)
+	end)
+
+	it("should iterate through the buckets if initial_bucket_index is full", terra()
+		var test_key = "i'm still here"
+		var test_hash_result = Plumbing.HashResult {
+			initial_bucket_index = 2,
+			h1 = 0,
+			h2 = 70
+		}
+		var test_metadata_array = arrayof(uint8, 128, 1, 2, 3, 4, 128, 128, 128)
+		var test_buckets_array = arrayof(rawstring, "0", "0", "0", "0", "0", "0", "0", "0")
+
+		var actual_index = Plumbing.probe(test_key, test_hash_result, test_metadata_array, test_buckets_array, 8)
+
+		assert.equal(actual_index, 5)
+	end)
+
+	it("should wrap around while probing", terra()
+		var test_key = "i'll be alive next year"
+		var test_hash_result = Plumbing.HashResult {
+			initial_bucket_index = 2,
+			h1 = 0,
+			h2 = 71
+		}
+		var test_metadata_array = arrayof(uint8, 128, 1, 2, 3, 4, 6, 7, 8)
+		var test_buckets_array = arrayof(rawstring, "0", "0", "0", "0", "0", "0", "0", "0")
+
+		var actual_index = Plumbing.probe(test_key, test_hash_result, test_metadata_array, test_buckets_array, 8)
+
+		assert.equal(actual_index, 0)
+	end)
+
+	it("should return -1 if full", terra()
+		var test_key = "i can make something good"
+		var test_hash_result = Plumbing.HashResult {
+			initial_bucket_index = 2,
+			h1 = 0,
+			h2 = 72
+		}
+		var test_metadata_array = arrayof(uint8, 9, 1, 2, 3, 4, 6, 7, 8)
+		var test_buckets_array = arrayof(rawstring, "0", "0", "0", "0", "0", "0", "0", "0")
+
+		var actual_index = Plumbing.probe(test_key, test_hash_result, test_metadata_array, test_buckets_array, 8)
+
+		assert.equal(actual_index, -1)
+	end)
+
+	it("should return -1 if initial_bucket_index is invalid", terra()
+		var test_key = "something good"
+		var test_hash_result = Plumbing.HashResult {
+			initial_bucket_index = 45,
+			h1 = 0,
+			h2 = 73
+		}
+		var test_metadata_array = arrayof(uint8, 9, 1, 2, 3, 4, 6, 7, 8)
+		var test_buckets_array = arrayof(rawstring, "0", "0", "0", "0", "0", "0", "0", "0")
+
+		var actual_index = Plumbing.probe(test_key, test_hash_result, test_metadata_array, test_buckets_array, 8)
+
+		assert.equal(actual_index, -1)
+	end)
+end)
+
+describe("HashTable", function()
+
+	it("should initalize metadata to MetadataEmpty", terra()
 		var hash_table: HT.HashTable(rawstring)
 		O.new(hash_table)
 
@@ -20,7 +116,7 @@ describe("Hash table", function()
 	end)
 
 	-- We should add a copy constructor and a capacity constructor.
-
+	
 	it("should insert entries", terra()
 		var hash_table: HT.HashTable(rawstring)
 		O.new(hash_table)
@@ -32,8 +128,6 @@ describe("Hash table", function()
 		hash_table:insert(str2)
 		hash_table:insert(str3)
 		
-		hash_table:debug_full_repr()	
-
 		assert.equal(hash_table.size, 3)
 		assert.is_true(hash_table:has(str1))
 		assert.is_true(hash_table:has(str2))
@@ -41,9 +135,9 @@ describe("Hash table", function()
 
 	end)
 
-	--[[
+
 	it("should resize automatically when enough entries are added", terra()
-		var hash_table: StringHashTable
+		var hash_table: HT.HashTable(rawstring)
 		O.new(hash_table)
 
 		var initial_capacity = hash_table.capacity
@@ -51,11 +145,9 @@ describe("Hash table", function()
 			var string_buffer = Alloc.calloc([int8], 10)
 			C.snprintf(string_buffer, 10, "i: %d", i)
 			hash_table:insert(string_buffer)
-
-			C.printf("Hashtable size: %d capacity: %d\n", hash_table.size, hash_table.capacity)
 		end
 		
-		debug_print_hashtable(hash_table)
+		hash_table:debug_full_repr()
 
 		assert.is_true(hash_table.capacity > initial_capacity)
 
@@ -64,5 +156,5 @@ describe("Hash table", function()
 				Alloc.free(hash_table.buckets[i])
 			end
 		end
-	end) ]]--
+	end)
 end)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -1,10 +1,26 @@
-local Str = require 'std.string'
+local O = require 'std.object'
 local HashTable = require 'std.hashtable'
 
 describe("Hash table", function()
-	local StringHashTable = HashTable(Str)
-	it("should have a constructor", terra()
+	local StringHashTable = HashTable(rawstring)
+	
+	it("should have a default constructor", terra()
 		var hash_table: HT
-		hash_table.init()
+		O.new(hash_table)
+	end)
+
+	-- We should add a copy constructor and a capacity constructor.
+
+	it("should insert and retrieve entries", terra()
+		var hash_table: HT
+		O.new(hash_table)
+
+		hash_table.insert("rawr")
+		hash_table.insert("X3")
+		hash_table.insert("OwO")
+
+		hash_table.entry("rawr")
+		hash_table.entry("X3")
+		hash_table.entry("OwO")
 	end)
 end)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -130,9 +130,54 @@ describe("HashTable with values", function()
 		hash_map:init()
 		hash_map:insert("shark girls", "are good")
 
-		var actual = hash_map:entry("shark girls")
+		var actual = hash_map:entry("shark girls").ok
 		assert.is_false(actual:is_empty())
 		assert.equal("shark girls", actual:key())
-		assert.equal("are good", actual:value())
+		assert.equal("are good", actual:value().ok)
+
+		hash_map:destruct()
+	end)
+
+	it("should create Entry objects for items that don't exist", terra()
+		var hash_map: StringHashMap
+		hash_map:init()
+
+		var actual = hash_map:entry("shark girls").ok
+		assert.is_true(actual:is_empty())
+
+		hash_map:destruct()
+	end)
+end)
+
+describe("Entry on HashMap", function()
+	local StringHashMap = HT.HashTable(rawstring, rawstring)
+
+	it("should insert a value if the value doesn't exist", terra()
+		var hash_map: StringHashMap
+		hash_map:init()
+
+		var sut = hash_map:entry("dark cat").ok
+		assert.is_true(sut:is_empty())
+		assert.equal("crazy milk", sut:or_insert("crazy milk"))
+		
+		assert.is_false(sut:is_empty())
+		assert.is_true(hash_map:has("dark cat"))
+		assert.equal("crazy milk", hash_map:get("dark cat").ok)
+
+		hash_map:destruct()
+	end)
+
+	it("should return the existing value if the value exists", terra()
+		var hash_map: StringHashMap
+		hash_map:init()
+		hash_map:insert("Porter Robinson", "Look at the Sky")
+		
+		var sut = hash_map:entry("Porter Robinson").ok
+		var actual = sut:or_insert("Musician")
+
+		assert.equal("Look at the Sky", actual)
+		assert.equal("Look at the Sky", hash_map:get("Porter Robinson").ok)
+
+		hash_map:destruct()
 	end)
 end)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -1,30 +1,23 @@
 local O = require 'std.object'
-local HashTable = require 'std.hashtable'
+local HT = require 'std.hashtable'
 local C = terralib.includec("stdio.h")
+local Alloc = require 'std.alloc'
+
+describe("Hashtable plumbing", function()
+	
+end)
 
 describe("Hash table", function()
-	local StringHashTable = HashTable(rawstring)
-
-	local terra debug_print_hashtable(hash_table: StringHashTable)
-		for i = 0, hash_table.capacity do
-			C.printf("[%d]\t%0#2X\t", i, hash_table.metadata[i])
-			if hash_table.metadata[i] == 128 then
-				C.printf("Empty\n")
-			else
-				C.printf("%s\n", hash_table.buckets[i])
-			end
-		end
-	end
 
 	it("should have a default constructor", terra()
-		var hash_table: StringHashTable
+		var hash_table: HT.HashTable(rawstring)
 		O.new(hash_table)
 	end)
 
 	-- We should add a copy constructor and a capacity constructor.
 
 	it("should insert entries", terra()
-		var hash_table: StringHashTable
+		var hash_table: HT.HashTable(rawstring)
 		O.new(hash_table)
 
 		var str1 = "According to all known laws of aviation"
@@ -35,10 +28,37 @@ describe("Hash table", function()
 		hash_table:insert(str2)
 		hash_table:insert(str3)
 		
+		hash_table:debug_repr()
+
 		assert.equal(hash_table.size, 3)
 		assert.is_true(hash_table:has(str1))
 		assert.is_true(hash_table:has(str2))
 		assert.is_true(hash_table:has(str3))
 
 	end)
+
+	--[[
+	it("should resize automatically when enough entries are added", terra()
+		var hash_table: StringHashTable
+		O.new(hash_table)
+
+		var initial_capacity = hash_table.capacity
+		for i = 0, (initial_capacity + 3) do
+			var string_buffer = Alloc.calloc([int8], 10)
+			C.snprintf(string_buffer, 10, "i: %d", i)
+			hash_table:insert(string_buffer)
+
+			C.printf("Hashtable size: %d capacity: %d\n", hash_table.size, hash_table.capacity)
+		end
+		
+		debug_print_hashtable(hash_table)
+
+		assert.is_true(hash_table.capacity > initial_capacity)
+
+		for i = 0, hash_table.capacity do
+			if hash_table.metadata[i] ~= 128 then
+				Alloc.free(hash_table.buckets[i])
+			end
+		end
+	end) ]]--
 end)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -105,9 +105,9 @@ describe("HashTable with values", function()
 		hash_map:insert("Super Dream World", "Kobaryo")
 		hash_map:insert("Does anyone actually", "read these things? lol")
 		hash_map:insert("I feel like tests", "are vastly underappreciated in software engineering.")
-		hash_map:insert("I don't have a choice", "I have to write extensive tests to save me from myself.")
-		hash_map:insert("The only way I can catch", "silly logic and syntax mistakes are with tests.")
-		hash_map:insert("they say that everyone makes", "these mistakes but idk.")
+		hash_map:insert("a", "b")
+		hash_map:insert("c", "d")
+		hash_map:insert("e", "f")
 
 		assert.equal(6, hash_map.size)
 
@@ -123,5 +123,16 @@ describe("HashTable with values", function()
 		assert.equal(HT.Errors.NotFound, remove_result.err)
 
 		hash_map:destruct()
+	end)
+
+	it("should create Entry objects for items that exist", terra()
+		var hash_map: StringHashMap
+		hash_map:init()
+		hash_map:insert("shark girls", "are good")
+
+		var actual = hash_map:entry("shark girls")
+		assert.is_false(actual:is_empty())
+		assert.equal("shark girls", actual:key())
+		assert.equal("are good", actual:value())
 	end)
 end)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -1,6 +1,7 @@
 local HT = require 'std.hashtable'
 local O = require 'std.object'
 
+local Cio = terralib.includec("stdio.h")
 
 describe("Hashtable without values", function()
 	local StringHashSet = HT.HashTable(rawstring)
@@ -13,11 +14,28 @@ describe("Hashtable without values", function()
 		assert.equal(0, hash_set:insert(expected._0))
 		assert.equal(0, hash_set:insert(expected._1))
 
-		hash_set:debug_full_repr()
-
 		assert.is_true(hash_set:has(expected._0))
 		assert.is_true(hash_set:has(expected._1))
 		assert.equal(2, hash_set.size)
+	end)
+
+	it("should resize its capacity without changing items", terra()
+		var hash_set = O.new(StringHashSet)
+
+		hash_set:insert("Cutiemarks")
+		hash_set:insert("and the")
+		hash_set:insert("things that")
+		hash_set:insert("bind us")
+
+		Cio.printf("Before resize:\n")
+		hash_set:debug_full_repr()
+
+		assert.equal(0, hash_set:reserve(31))
+
+		Cio.printf("After resize:\n")
+		hash_set:debug_full_repr()
+		assert.equal(4, hash_set.size)
+		assert.is_true(hash_set.capacity >= 31)
 	end)
 end)
 
@@ -31,8 +49,6 @@ describe("Implementation.DenseHashTable HashMap", function()
 		assert.equal(0, hash_map:insert("if ya pull yourself together", "you can get on your feet"))
 		assert.equal(0, hash_map:insert("living proof that", "the strength you will need"))
 		assert.equal(0, hash_map:insert("has been in you forever", "but to get it, you'll bleed"))
-
-		hash_map:debug_full_repr()
 
 		assert.is_true(hash_map:has("I'm living proof"))
 		assert.is_true(hash_map:has("if ya pull yourself together"))

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -4,16 +4,44 @@ local CIO = terralib.includec("stdio.h")
 local CStr = terralib.includec("string.h")
 local Alloc = require 'std.alloc'
 
-describe("Implementation.DenseHashTable", function()
-	local StringHashSet = HT.Implementation.DenseHashTable(rawstring, nil, HT.CreateDefaultHashFunction(rawstring), HT.CreateDefaultEqualityFunction(rawstring), Alloc.default_allocator)
+describe("Implementation.DenseHashTable HashSet", function()
+	local IntegerHashSet = HT.Implementation.DenseHashTable(int, nil, HT.CreateDefaultHashFunction(int), HT.CreateDefaultEqualityFunction(int), Alloc.default_allocator)
 
-	local StringHashMap = HT.Implementation.DenseHashTable(rawstring, rawstring, HT.CreateDefaultHashFunction(rawstring), HT.CreateDefaultHashFunction(rawstring), Alloc.default_allocator)
+	it("should allow you to insert items", terra()
+		var hash_set: IntegerHashSet
+		O.new(hash_set)
+ 
+		var expected = 621
+		var handle = hash_set:lookup_handle(expected)
+		var store_result = hash_set:store_handle(handle, expected)
 
-	it("hash set form should satisfy the CTHashTable constraint", function()
-		HT.CTHashTable(StringHashSet)
+		assert.is_true(store_result == 0)
 	end)
 
-	if("hash map form should satisfy the CTHashTable constraint", function()
-		HT.CTHashTable(StringHashMap)
+end)
+
+describe("Implementation.DenseHashTable HashMap", function()
+	local StringHashMap = HT.Implementation.DenseHashTable(rawstring, rawstring, HT.CreateDefaultHashFunction(rawstring), HT.CreateDefaultEqualityFunction(rawstring), Alloc.default_allocator)
+	
+	it("should allow you to insert items", terra()
+		var hash_map: StringHashMap
+		O.new(hash_map)
+
+		var expected_key1 = "Summer Kennedy"
+		var expected_value1 = "Oh My My"
+
+		var expected_key2 = "Des Rocs"
+		var expected_value2 = "Living Proof"
+
+		var handle1 = hash_map:lookup_handle(expected_key1)
+		var handle2 = hash_map:lookup_handle(expected_key2)
+
+		var store_result1 = hash_map:store_handle(handle1, expected_key1, expected_value1)
+		var store_result2 = hash_map:store_handle(handle2, expected_key2, expected_value2)
+
+		assert.is_true(store_result1 == 0)
+		assert.is_true(store_result2 == 0)
+
+		hash_map:debug_full_repr()
 	end)
 end)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -1,0 +1,10 @@
+local Str = require 'std.string'
+local HashTable = require 'std.hashtable'
+
+describe("Hash table", function()
+	local StringHashTable = HashTable(Str)
+	it("should have a constructor", terra()
+		var hash_table: HT
+		hash_table.init()
+	end)
+end)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -19,23 +19,42 @@ describe("Hashtable without values", function()
 		assert.equal(2, hash_set.size)
 	end)
 
+	
 	it("should resize its capacity without changing items", terra()
-		var hash_set = O.new(StringHashSet)
+		var hash_set: StringHashSet
+		hash_set:init()
 
 		hash_set:insert("Cutiemarks")
 		hash_set:insert("and the")
 		hash_set:insert("things that")
 		hash_set:insert("bind us")
 
-		Cio.printf("Before resize:\n")
-		hash_set:debug_full_repr()
 
 		assert.equal(0, hash_set:reserve(31))
-
-		Cio.printf("After resize:\n")
-		hash_set:debug_full_repr()
 		assert.equal(4, hash_set.size)
 		assert.is_true(hash_set.capacity >= 31)
+
+		hash_set:destruct()
+	end)
+
+	it("should be able to remove keys", terra()
+		var hash_set: StringHashSet
+		hash_set:init()
+
+		hash_set:insert("I'm filled")
+		hash_set:insert("with")
+		hash_set:insert("wanderlust")
+
+		-- Should remove the item and return it.
+		assert.equal(3, hash_set.size)
+		assert.equal("I'm filled", hash_set:remove("I'm filled").ok.key)
+		assert.equal(2, hash_set.size)
+
+		-- Should return an error
+		assert.equal(HT.Errors.NotFound, hash_set:remove("doesn't exist").err)
+		assert.equal(2, hash_set.size)
+
+		hash_set:destruct()
 	end)
 end)
 
@@ -55,5 +74,32 @@ describe("Implementation.DenseHashTable HashMap", function()
 		assert.is_true(hash_map:has("living proof that"))
 		assert.is_true(hash_map:has("has been in you forever"))
 		assert.equal(4, hash_map.size)
+	end)
+
+	it("should be able to remove items by keys", terra()
+		var hash_map: StringHashMap
+		hash_map:init()
+
+		hash_map:insert("Super Dream World", "Kobaryo")
+		hash_map:insert("Does anyone actually", "read these things? lol")
+		hash_map:insert("I feel like tests", "are vastly underappreciated in software engineering.")
+		hash_map:insert("I don't have a choice", "I have to write extensive tests to save me from myself.")
+		hash_map:insert("The only way I can catch", "silly logic and syntax mistakes are with tests.")
+		hash_map:insert("they say that everyone makes", "these mistakes but idk.")
+
+		assert.equal(6, hash_map.size)
+
+		var remove_result = hash_map:remove("Super Dream World")
+		assert.is_true(remove_result:is_ok())
+		assert.equal(5, hash_map.size)
+		assert.equal("Super Dream World", remove_result.ok.key)
+		assert.equal("Kobaryo", remove_result.ok.value)
+
+		remove_result = hash_map:remove("404 not found")
+		assert.is_true(remove_result:is_err())
+		assert.equal(5, hash_map.size)
+		assert.equal(HT.Errors.NotFound, remove_result.err)
+
+		hash_map:destruct()
 	end)
 end)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -1,26 +1,31 @@
 local O = require 'std.object'
 local HashTable = require 'std.hashtable'
+local C = terralib.includec("stdio.h")
 
 describe("Hash table", function()
 	local StringHashTable = HashTable(rawstring)
 	
 	it("should have a default constructor", terra()
-		var hash_table: HT
+		var hash_table: StringHashTable
 		O.new(hash_table)
 	end)
 
 	-- We should add a copy constructor and a capacity constructor.
 
-	it("should insert and retrieve entries", terra()
-		var hash_table: HT
+	it("should insert entries", terra()
+		var hash_table: StringHashTable
 		O.new(hash_table)
 
-		hash_table.insert("rawr")
-		hash_table.insert("X3")
-		hash_table.insert("OwO")
+		hash_table:insert("rawr")
+		hash_table:insert("X3")
+		hash_table:insert("OwO")
 
-		hash_table.entry("rawr")
-		hash_table.entry("X3")
-		hash_table.entry("OwO")
+		var a = hash_table:entry("rawr")
+		var b = hash_table:entry("X3")
+		var c = hash_table:entry("OwO")
+
+		C.printf("[a] %x - %s\n", @a.metadata, @a.bucket)
+		C.printf("[b] %x - %s\n", @b.metadata, @b.bucket)
+		C.printf("[c] %x - %s\n", @c.metadata, @c.bucket)
 	end)
 end)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -88,9 +88,14 @@ describe("HashTable without values", function()
 		hash_set:insert("City Lights")
 
 		hash_set:remove("Broken Arrows")
+		hash_set:remove("Somewhere in Stockholm")
+		hash_set:remove("City Lights")
+
 		hash_set:reserve(31)
 
-		hash_set:debug_full_repr()
+		for i = 0, hash_set.capacity do
+			assert.is_true(hash_set.metadata[i] == 128)
+		end
 
 		hash_set:destruct()
 	end)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -1,49 +1,24 @@
-local O = require 'std.object'
 local HT = require 'std.hashtable'
-local CIO = terralib.includec("stdio.h")
-local CStr = terralib.includec("string.h")
-local Alloc = require 'std.alloc'
+local O = require 'std.object'
 
-describe("Implementation.DenseHashTable HashSet", function()
-	local BucketType = HT.Implementation.BucketType(int)
-	local IntegerHashSet = HT.Implementation.DenseHashTable(BucketType, HT.CreateDefaultHashFunction(int), HT.CreateDefaultEqualityFunction(int), Alloc.default_allocator)
 
-	it("should allow you to insert items", terra()
-		var hash_set: IntegerHashSet
-		O.new(hash_set)
- 
-		var expected = 621
-		var handle = hash_set:lookup_handle(expected)
-		var store_result = hash_set:store_handle(handle, expected)
+describe("Hashtable without values", function()
+	local StringHashSet = HT.HashTable(rawstring)
 
-		assert.is_true(store_result == 0)
+	it("should insert and check the existence of values", terra()
+		var hash_set = O.new(StringHashSet)
+
+		var expected = {"STRONK", "Identity"}
+
+		hash_set.insert(expected._1)
+		hash_set.insert(expected._2)
+
+		hash_set.debug_full_repr()
+
+		assert.is_true(hash_set.has(expected._1))
+		assert.is_true(hash_set.has(expected._2))
 	end)
-
 end)
 
 describe("Implementation.DenseHashTable HashMap", function()
-	local BucketType = HT.Implementation.BucketType(rawstring, rawstring)
-	local StringHashMap = HT.Implementation.DenseHashTable(BucketType, HT.CreateDefaultHashFunction(rawstring), HT.CreateDefaultEqualityFunction(rawstring), Alloc.default_allocator)
-	
-	it("should allow you to insert items", terra()
-		var hash_map: StringHashMap
-		O.new(hash_map)
-
-		var expected_key1 = "Summer Kennedy"
-		var expected_value1 = "Oh My My"
-
-		var expected_key2 = "Des Rocs"
-		var expected_value2 = "Living Proof"
-
-		var handle1 = hash_map:lookup_handle(expected_key1)
-		var handle2 = hash_map:lookup_handle(expected_key2)
-
-		var store_result1 = hash_map:store_handle(handle1, expected_key1, expected_value1)
-		var store_result2 = hash_map:store_handle(handle2, expected_key2, expected_value2)
-
-		assert.is_true(store_result1 == 0)
-		assert.is_true(store_result2 == 0)
-
-		hash_map:debug_full_repr()
-	end)
 end)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -1,180 +1,19 @@
 local O = require 'std.object'
 local HT = require 'std.hashtable'
-local C = terralib.includec("stdio.h")
+local CIO = terralib.includec("stdio.h")
 local CStr = terralib.includec("string.h")
 local Alloc = require 'std.alloc'
 
-describe("_Plumbing.table_calloc", function()
-	local StringHashTableModule = HT.CreateHashTableSubModule(rawstring)
-	local Plumbing = StringHashTableModule._Plumbing
+describe("Implementation.DenseHashTable", function()
+	local StringHashSet = HT.Implementation.DenseHashTable(rawstring, nil, HT.CreateDefaultHashFunction(rawstring), HT.CreateDefaultEqualityFunction(rawstring), Alloc.default_allocator)
 
-	it("should allocate enough memory and initalize the metadata portion", terra()
-		var capacity = 8
-		var alloc_success, opaque_ptr, metadata_array, buckets_array = Plumbing.table_calloc(capacity)
+	local StringHashMap = HT.Implementation.DenseHashTable(rawstring, rawstring, HT.CreateDefaultHashFunction(rawstring), HT.CreateDefaultHashFunction(rawstring), Alloc.default_allocator)
 
-		assert.is_true(alloc_success)
-		assert.is_true(opaque_ptr ~= nil)
-
-		for i = 0, capacity do
-			assert.equal(metadata_array[i], 128)
-		end
-
-		Alloc.free(opaque_ptr)
-	end)
-end)
-
-describe("_Plumbing.probe", function()
-	local StringHashTableModule = HT.CreateHashTableSubModule(rawstring)
-	local Plumbing = StringHashTableModule._Plumbing
-
-	it("should use initial_bucket_index if the bucket is empty", terra()
-		var test_key = "look at the sky"
-		var test_hash_result = Plumbing.HashResult {
-			initial_bucket_index = 5,
-			h1 = 0,
-			h2 = 69
-		}
-		var test_metadata_array = arrayof(uint8, 128, 128, 128, 128, 128, 128, 128, 128)
-		var test_buckets_array = arrayof(rawstring, "0", "0", "0", "0", "0", "0", "0", "0")
-
-		var actual_index = Plumbing.probe(test_key, test_hash_result, test_metadata_array, test_buckets_array, 8)
-
-		assert.equal(actual_index, test_hash_result.initial_bucket_index)
+	it("hash set form should satisfy the CTHashTable constraint", function()
+		HT.CTHashTable(StringHashSet)
 	end)
 
-	it("should iterate through the buckets if initial_bucket_index is full", terra()
-		var test_key = "i'm still here"
-		var test_hash_result = Plumbing.HashResult {
-			initial_bucket_index = 2,
-			h1 = 0,
-			h2 = 70
-		}
-		var test_metadata_array = arrayof(uint8, 128, 1, 2, 3, 4, 128, 128, 128)
-		var test_buckets_array = arrayof(rawstring, "0", "0", "0", "0", "0", "0", "0", "0")
-
-		var actual_index = Plumbing.probe(test_key, test_hash_result, test_metadata_array, test_buckets_array, 8)
-
-		assert.equal(actual_index, 5)
-	end)
-
-	it("should wrap around while probing", terra()
-		var test_key = "i'll be alive next year"
-		var test_hash_result = Plumbing.HashResult {
-			initial_bucket_index = 2,
-			h1 = 0,
-			h2 = 71
-		}
-		var test_metadata_array = arrayof(uint8, 128, 1, 2, 3, 4, 6, 7, 8)
-		var test_buckets_array = arrayof(rawstring, "0", "0", "0", "0", "0", "0", "0", "0")
-
-		var actual_index = Plumbing.probe(test_key, test_hash_result, test_metadata_array, test_buckets_array, 8)
-
-		assert.equal(actual_index, 0)
-	end)
-
-	it("should return -1 if full", terra()
-		var test_key = "i can make something good"
-		var test_hash_result = Plumbing.HashResult {
-			initial_bucket_index = 2,
-			h1 = 0,
-			h2 = 72
-		}
-		var test_metadata_array = arrayof(uint8, 9, 1, 2, 3, 4, 6, 7, 8)
-		var test_buckets_array = arrayof(rawstring, "0", "0", "0", "0", "0", "0", "0", "0")
-
-		var actual_index = Plumbing.probe(test_key, test_hash_result, test_metadata_array, test_buckets_array, 8)
-
-		assert.equal(actual_index, -1)
-	end)
-
-	it("should return -1 if initial_bucket_index is invalid", terra()
-		var test_key = "something good"
-		var test_hash_result = Plumbing.HashResult {
-			initial_bucket_index = 45,
-			h1 = 0,
-			h2 = 73
-		}
-		var test_metadata_array = arrayof(uint8, 9, 1, 2, 3, 4, 6, 7, 8)
-		var test_buckets_array = arrayof(rawstring, "0", "0", "0", "0", "0", "0", "0", "0")
-
-		var actual_index = Plumbing.probe(test_key, test_hash_result, test_metadata_array, test_buckets_array, 8)
-
-		assert.equal(actual_index, -1)
-	end)
-end)
-
-describe("_Plumbing.resize_hashtable", function()
-	local StringHashTableModule = HT.CreateHashTableSubModule(rawstring)
-	local Plumbing = StringHashTableModule._Plumbing
-
-	it("should double the size of a hash_table", terra()
-		var test_table: StringHashTableModule.HashTable
-		O.new(test_table)
-
-		test_table:insert("the coldest summer for the rest of your life")
-
-		var old_capacity = test_table.capacity
-		var old_size = test_table.size
-
-		var result = Plumbing.resize_hashtable(&test_table)
-		assert.is_true(result)
-		assert.is_true(old_size == test_table.size)
-		assert.is_true(old_capacity * 2 == test_table.capacity)
-	end)
-end)
-
-describe("HashTable", function()
-
-	it("should initalize metadata to MetadataEmpty", terra()
-		var hash_table: HT.HashTable(rawstring)
-		O.new(hash_table)
-
-		-- Assert that metadata is initalized
-		for i = 0, hash_table.capacity do
-			assert.equal(hash_table.metadata[i], 128)
-		end
-	end)
-
-	-- We should add a copy constructor and a capacity constructor.
-	
-	it("should insert entries", terra()
-		var hash_table: HT.HashTable(rawstring)
-		O.new(hash_table)
-		
-		var str1 = "According to all known laws of aviation"
-		var str2 = "there is no way that a be should be able to fly"
-		var str3 = "Its wings are too small to get its fat little body off the ground"
-		hash_table:insert(str1)
-		hash_table:insert(str2)
-		hash_table:insert(str3)
-		
-		assert.equal(hash_table.size, 3)
-		assert.is_true(hash_table:has(str1))
-		assert.is_true(hash_table:has(str2))
-		assert.is_true(hash_table:has(str3))
-		assert.is_false(hash_table:has("This string doesn't exist"))
-	end)
-
-
-	it("should resize automatically when enough entries are added", terra()
-		var hash_table: HT.HashTable(rawstring)
-		O.new(hash_table)
-
-		var initial_capacity = hash_table.capacity
-		for i = 0, (initial_capacity + 3) do
-			var string_buffer = Alloc.calloc([int8], 10)
-			C.snprintf(string_buffer, 10, "i: %d", i)
-			hash_table:insert(string_buffer)
-		end
-		
-		hash_table:debug_full_repr()
-
-		assert.is_true(hash_table.capacity > initial_capacity)
-
-		for i = 0, hash_table.capacity do
-			if hash_table.metadata[i] ~= 128 then
-				Alloc.free(hash_table.buckets[i])
-			end
-		end
+	if("hash map form should satisfy the CTHashTable constraint", function()
+		HT.CTHashTable(StringHashMap)
 	end)
 end)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -15,8 +15,6 @@ describe("HashTable without values", function()
 		assert.equal(0, hash_set:insert(expected._0))
 		assert.equal(0, hash_set:insert(expected._1))
 
-		hash_set:debug_full_repr()
-
 		assert.is_true(hash_set:has(expected._0))
 		assert.is_true(hash_set:has(expected._1))
 		assert.equal(2, hash_set.size)
@@ -67,21 +65,21 @@ describe("HashTable without values", function()
 			return 1
 		end
 
-		local BadStringHashMap = HT.HashTable(rawstring, nil, bad_hash_function) 
+		local BadStringHashSet = HT.HashTable(rawstring, nil, bad_hash_function) 
 
 		local terra test()
-			var hash_map: BadStringHashMap
-			hash_map:init()
+			var hash_set: BadStringHashSet
+			hash_set:init()
 
-			hash_map:insert("1")
-			hash_map:insert("2")
-			hash_map:insert("3")
+			hash_set:insert("1")
+			hash_set:insert("2")
+			hash_set:insert("3")
 		
-			assert.is_true(hash_map:remove("1"):is_ok())
-			assert.is_true(hash_map:remove("2"):is_ok())
-			assert.is_true(hash_map:remove("3"):is_ok())
+			assert.is_true(hash_set:remove("1"):is_ok())
+			assert.is_true(hash_set:remove("2"):is_ok())
+			assert.is_true(hash_set:remove("3"):is_ok())
 
-			hash_map:destruct()
+			hash_set:destruct()
 		end
 
 		test()

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -199,6 +199,11 @@ describe("HashTable with values", function()
 		assert.equal("Super Dream World", remove_result.ok.key)
 		assert.equal("Kobaryo", remove_result.ok.value)
 		assert.is_false(hash_map:has("Super Dream World"))
+		
+		-- Make sure that :get returns a not found error on a deleted entry
+		var get_result = hash_map:get("Super Dream World")
+		assert.is_true(get_result:is_err())
+		assert.equal(HT.Errors.NotFound, get_result.err)
 
 		remove_result = hash_map:remove("404 not found")
 		assert.is_true(remove_result:is_err())

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -62,9 +62,9 @@ describe("HashTable without values", function()
 		hash_set:init()
 		hash_set:insert("sharks")
 
-		var actual = hash_set.entry("sharks")
-		assert.is_false(actual.is_empty())
-		assert.equal("sharks", hash_set.key())
+		var actual = hash_set:entry("sharks").ok
+		assert.is_false(actual:is_empty())
+		assert.equal("sharks", actual:key())
 
 		hash_set:destruct()
 	end)
@@ -73,8 +73,8 @@ describe("HashTable without values", function()
 		var hash_set: StringHashSet
 		hash_set:init()
 
-		var actual = hash_set.entry("shark")
-		assert.is_true(actual.is_empty())
+		var actual = hash_set:entry("shark").ok
+		assert.is_true(actual:is_empty())
 
 		hash_set:destruct()
 	end)

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -10,13 +10,14 @@ describe("Hashtable without values", function()
 
 		var expected = {"STRONK", "Identity"}
 
-		hash_set.insert(expected._1)
-		hash_set.insert(expected._2)
+		assert.equal(0, hash_set:insert(expected._0))
+		assert.equal(0, hash_set:insert(expected._1))
 
-		hash_set.debug_full_repr()
+		hash_set:debug_full_repr()
 
-		assert.is_true(hash_set.has(expected._1))
-		assert.is_true(hash_set.has(expected._2))
+		assert.is_true(hash_set:has(expected._0))
+		assert.is_true(hash_set:has(expected._1))
+		assert.equal(2, hash_set.size)
 	end)
 end)
 

--- a/spec/hashtable_spec.t
+++ b/spec/hashtable_spec.t
@@ -4,7 +4,18 @@ local C = terralib.includec("stdio.h")
 
 describe("Hash table", function()
 	local StringHashTable = HashTable(rawstring)
-	
+
+	local terra debug_print_hashtable(hash_table: StringHashTable)
+		for i = 0, hash_table.capacity do
+			C.printf("[%d]\t%0#2X\t", i, hash_table.metadata[i])
+			if hash_table.metadata[i] == 128 then
+				C.printf("Empty\n")
+			else
+				C.printf("%s\n", hash_table.buckets[i])
+			end
+		end
+	end
+
 	it("should have a default constructor", terra()
 		var hash_table: StringHashTable
 		O.new(hash_table)
@@ -16,22 +27,18 @@ describe("Hash table", function()
 		var hash_table: StringHashTable
 		O.new(hash_table)
 
-		hash_table:insert("rawr")
-		hash_table:insert("X3")
-		hash_table:insert("OwO")
+		var str1 = "According to all known laws of aviation"
+		var str2 = "there is no way that a be should be able to fly"
+		var str3 = "Its wings are too small to get its fat little body off the ground"
 
-		for i = 0, hash_table.capacity do
-			C.printf("[%d] %x\t", i, hash_table.metadata[i])
-			if hash_table.metadata[i] == 128 then
-				C.printf("Empty\n")
-			else
-				C.printf("%s\n", hash_table.buckets[i])
-			end
-		end
-
-		assert hash_table:has("rawr")
-		assert hash_table:has("X3")
-		assert hash_table:has("OwO")
+		hash_table:insert(str1)
+		hash_table:insert(str2)
+		hash_table:insert(str3)
+		
+		assert.equal(hash_table.size, 3)
+		assert.is_true(hash_table:has(str1))
+		assert.is_true(hash_table:has(str2))
+		assert.is_true(hash_table:has(str3))
 
 	end)
 end)

--- a/spec/result_spec.t
+++ b/spec/result_spec.t
@@ -1,0 +1,10 @@
+local R = require "std.result"
+
+describe("std.result", function()
+	local IntResult = R.MakeResult(int, int) 
+
+	it("can be instantiated in both okay and error alternatives", terra()
+		var okay = IntResult.ok(42)
+		var err = IntResult.err(76)
+	end)
+end)

--- a/spec/result_spec.t
+++ b/spec/result_spec.t
@@ -13,6 +13,13 @@ describe("ErrorResult", function()
 		assert.is_true(to:is_err())
 		assert.equal(709, to.err)
 	end)
+
+	it("reports is_err and is_ok correctly", terra()
+		var sut = TestError { 709 }
+
+		assert.is_true(sut:is_err())
+		assert.is_false(sut:is_ok())
+	end)
 end)
 
 describe("OkayResult", function()
@@ -24,6 +31,13 @@ describe("OkayResult", function()
 
 		assert.is_true(to:is_ok())
 		assert.equal(147.762, to.ok)
+	end)
+
+	it("reports is_err and is_ok correctly", terra()
+		var sut = TestOkay { 147.762 }
+
+		assert.is_true(sut:is_ok())
+		assert.is_false(sut:is_err())
 	end)
 end)
 

--- a/spec/result_spec.t
+++ b/spec/result_spec.t
@@ -1,4 +1,5 @@
 local R = require "std.result"
+local Cio = terralib.includec("stdio.h")
 
 local TestResult = R.MakeResult(double, int)
 
@@ -6,11 +7,14 @@ describe("ErrorResult", function()
 	local TestError = R.MakeErrorResult(TestResult.type_parameters.ErrorType)
 
 	it("can be casted to a full Result type", terra()
-		var from: TestError(708)
-		var to: TestResult = from
+		var from: TestError = TestError.err(708)
+		Cio.printf("from: %d\n", from.err)
+		-- Implicit casts don't work for structs it seems
+		var to: TestResult = [TestResult](from)
 
+		--[[
 		assert.is_true(to:is_err())
-		assert.equal(709, to.err)
+		assert.equal(709, to.err) ]]--
 	end)
 end)
 
@@ -18,8 +22,8 @@ describe("OkayResult", function()
 	local TestOkay = R.MakeOkayResult(TestResult.type_parameters.OkayType)
 
 	it("can be casted to a full Result type", terra()
-		var from = TestOkay(147.762)
-		var to: TestResult = from
+		var from: TestOkay = TestOkay.ok(147.762)
+		var to = [TestResult](from)
 
 		assert.is_true(to:is_ok())
 		assert.equal(147.762, to.ok)

--- a/spec/result_spec.t
+++ b/spec/result_spec.t
@@ -7,14 +7,11 @@ describe("ErrorResult", function()
 	local TestError = R.MakeErrorResult(TestResult.type_parameters.ErrorType)
 
 	it("can be casted to a full Result type", terra()
-		var from: TestError = TestError.err(708)
-		Cio.printf("from: %d\n", from.err)
-		-- Implicit casts don't work for structs it seems
+		var from: TestError = TestError { 709 }
 		var to: TestResult = [TestResult](from)
 
-		--[[
 		assert.is_true(to:is_err())
-		assert.equal(709, to.err) ]]--
+		assert.equal(709, to.err)
 	end)
 end)
 
@@ -22,8 +19,8 @@ describe("OkayResult", function()
 	local TestOkay = R.MakeOkayResult(TestResult.type_parameters.OkayType)
 
 	it("can be casted to a full Result type", terra()
-		var from: TestOkay = TestOkay.ok(147.762)
-		var to = [TestResult](from)
+		var from: TestOkay = TestOkay { 147.762 }
+		var to: TestResult = [TestResult](from)
 
 		assert.is_true(to:is_ok())
 		assert.equal(147.762, to.ok)
@@ -39,4 +36,14 @@ describe("std.result", function()
 		var err = TestResult.err(76)
 	end)
 
+	it("can check which alternative it is", terra()
+		var okay = TestResult.ok(42.3)
+		var err = TestResult.err(76)
+
+		assert.is_true(okay:is_ok())
+		assert.is_false(okay:is_err())
+
+		assert.is_false(err:is_ok())
+		assert.is_true(err:is_err())
+	end)
 end)

--- a/spec/result_spec.t
+++ b/spec/result_spec.t
@@ -8,7 +8,7 @@ describe("ErrorResult", function()
 
 	it("can be casted to a full Result type", terra()
 		var from: TestError = TestError { 709 }
-		var to: TestResult = [TestResult](from)
+		var to: TestResult = from -- Implicit cast
 
 		assert.is_true(to:is_err())
 		assert.equal(709, to.err)
@@ -27,7 +27,7 @@ describe("OkayResult", function()
 
 	it("can be casted to a full Result type", terra()
 		var from: TestOkay = TestOkay { 147.762 }
-		var to: TestResult = [TestResult](from)
+		var to: TestResult = from -- Implicit cast
 
 		assert.is_true(to:is_ok())
 		assert.equal(147.762, to.ok)

--- a/spec/result_spec.t
+++ b/spec/result_spec.t
@@ -1,10 +1,38 @@
 local R = require "std.result"
 
+local TestResult = R.MakeResult(double, int)
+
+describe("ErrorResult", function()
+	local TestError = R.MakeErrorResult(TestResult.type_parameters.ErrorType)
+
+	it("can be casted to a full Result type", terra()
+		var from: TestError(708)
+		var to: TestResult = from
+
+		assert.is_true(to:is_err())
+		assert.equal(709, to.err)
+	end)
+end)
+
+describe("OkayResult", function()
+	local TestOkay = R.MakeOkayResult(TestResult.type_parameters.OkayType)
+
+	it("can be casted to a full Result type", terra()
+		var from = TestOkay(147.762)
+		var to: TestResult = from
+
+		assert.is_true(to:is_ok())
+		assert.equal(147.762, to.ok)
+	end)
+end)
+
 describe("std.result", function()
-	local IntResult = R.MakeResult(int, int) 
+	local TestOkay = R.MakeOkayResult(double)
+	local TestError = R.MakeErrorResult(int)
 
 	it("can be instantiated in both okay and error alternatives", terra()
-		var okay = IntResult.ok(42)
-		var err = IntResult.err(76)
+		var okay = TestResult.ok(42.3)
+		var err = TestResult.err(76)
 	end)
+
 end)


### PR DESCRIPTION
Defines a basic hashtable implementation, and a Result type implementation.

Hashtable support insertion, removal, validation, and resize operations. It also has a rudimentary entry API.

At a later point, I would like to implement a dynamic array/list type in the standard library and use that to support iteration over the hashtable. 